### PR TITLE
bld: add prek cog lychee and docs release gates

### DIFF
--- a/.github/workflows/ci_cxx.yml
+++ b/.github/workflows/ci_cxx.yml
@@ -90,8 +90,8 @@ jobs:
           bash scripts/package-cxx.sh /tmp/cxx-out
           TAR=$(ls /tmp/cxx-out/readcon-core-cxx-*.tar.gz | grep -v vendor | head -1)
           tar -tzf "$TAR" | grep -E 'include/readcon-core\.h$'
-          if tar -tzf "$TAR" | grep -E 'cbindgen'; then
-            echo "cxx tarball must not require cbindgen" >&2
+          if tar -tzf "$TAR" | grep -E '(^|/)cbindgen(\.toml)?$'; then
+            echo "cxx tarball must not ship cbindgen.toml or a cbindgen binary" >&2
             exit 1
           fi
           SHA=$(sha256sum "$TAR" | awk '{print $1}')

--- a/.github/workflows/ci_prek.yml
+++ b/.github/workflows/ci_prek.yml
@@ -1,0 +1,20 @@
+name: lints
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lints:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Run prek
+        run: uvx prek run -a -vvv

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ jobs:
 
     - name: Conventional commits check
       uses: cocogitto/cocogitto-action@v3
+      with:
+        # Full-history check dies on pre-v0.14 `docs+bench:` / untyped merges.
+        check-latest-tag-only: true
 
     - name: Audit for large files
       uses: HaoZeke/large-file-auditor@v0.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -102,14 +102,14 @@ CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
 Makefile
-install_manifest.txt 
+install_manifest.txt
 compile_commands.json
 
 # Temporary files
-*.tmp 
-*.log 
-*.bak 
-*.swp 
+*.tmp
+*.log
+*.bak
+*.swp
 
 # vcpkg
 vcpkg_installed/
@@ -377,9 +377,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,14 @@ crate-type = ["lib", "cdylib", "staticlib"]
 default = []
 capi = []
 parallel = ["rayon"]
-rpc = ["dep:capnp", "dep:capnp-rpc", "dep:capnpc", "dep:tokio", "dep:tokio-util", "dep:futures"]
+rpc = [
+  "dep:capnp",
+  "dep:capnp-rpc",
+  "dep:capnpc",
+  "dep:tokio",
+  "dep:tokio-util",
+  "dep:futures",
+]
 # NB: dlpk/pyo3 is intentionally NOT activated -- dlpk v0.1.5 pins
 # pyo3 = "0.26" but readcon-core's python.rs is on pyo3 0.28, and
 # pyo3-ffi is `links = "python"` so the two cannot coexist in the
@@ -73,7 +80,13 @@ rustc-hash = "2"
 rayon = { version = "1.10", optional = true }
 capnp = { version = "0.20", optional = true }
 capnp-rpc = { version = "0.20", optional = true }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "macros", "time"], optional = true }
+tokio = { version = "1", features = [
+  "rt",
+  "rt-multi-thread",
+  "net",
+  "macros",
+  "time",
+], optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
 futures = { version = "0.3", optional = true }
 pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
@@ -82,7 +95,10 @@ metatensor = { version = "0.3.0-rc2", optional = true }
 zstd = { version = "0.13", optional = true }
 chemfiles = { version = "0.10", optional = true }
 # Driver API for cudaMalloc/cudaMemcpy; versions track CUDA major loosely.
-cudarc = { version = "0.13", optional = true, default-features = false, features = ["cuda-12040", "driver"] }
+cudarc = { version = "0.13", optional = true, default-features = false, features = [
+  "cuda-12040",
+  "driver",
+] }
 pest = { version = "2.8", optional = true }
 pest_derive = { version = "2.8", optional = true }
 
@@ -119,9 +135,9 @@ description = "CON/convel file reader and writer with FFI, Python, Julia binding
 
 [package.metadata.capi.install.include]
 asset = [
-    { from = "include/readcon-core.h" },
-    { from = "include/readcon-core.hpp" },
-    { from = "include/readcon-metatensor.h" },
+  { from = "include/readcon-core.h" },
+  { from = "include/readcon-core.hpp" },
+  { from = "include/readcon-metatensor.h" },
 ]
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ One Good Tutorial (Diátaxis): install, read a multi-frame fixture, inspect
 Short Python path from the repository root:
 
     import readcon
-    
+
     for frame in readcon.iter_con("resources/test/tiny_multi_cuh2.con"):
         print(frame.cell, len(frame), frame.energy)
-    
+
     frames = readcon.read_con("resources/test/tiny_multi_cuh2.con")
     readcon.write_con("out.con", frames)
-    
+
     atoms = [readcon.Atom("Cu", 0.0, 0.0, 0.0, atom_id=0, mass=63.546)]
     frame = readcon.ConFrame(cell=[10.0, 10.0, 10.0], angles=[90.0, 90.0, 90.0], atoms=atoms)
     frame.set_energy(-42.5)
@@ -360,4 +360,3 @@ If you use `readcon-core` in academic work, please cite it via the metadata in [
 # License
 
 MIT.
-

--- a/cog.toml
+++ b/cog.toml
@@ -42,8 +42,6 @@ feat = { changelog_title = "Features" }
 
 [changelog]
 path = "CHANGELOG.md"
-authors = [
-        { username = "HaoZeke", signature = "Rohit Goswami" }
-]
+authors = [{ username = "HaoZeke", signature = "Rohit Goswami" }]
 
 [bump_profiles]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,11 +18,11 @@ installers = []
 # after the GitHub Release is published. cargo-c remains a third
 # install path; cbindgen is not required.
 targets = [
-    "aarch64-apple-darwin",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
 ]
 github-releases = true
 # Create GitHub releases from the tag; PR mode only plans.

--- a/docs/orgmode/architecture.org
+++ b/docs/orgmode/architecture.org
@@ -215,4 +215,3 @@ authoritative on disk and in corpora.
 Related work and roles: [[file:faq.org][faq.org]]. Spec:
 [[file:spec.org][spec.org]]. Evolution: [[file:evolution.org][evolution.org]].
 Measurements: [[file:benchmarks.org][benchmarks.org]].
-

--- a/docs/orgmode/contributing.org
+++ b/docs/orgmode/contributing.org
@@ -8,6 +8,8 @@
 - Rust >= 1.88 (edition 2024)
 - [[https://pixi.sh][pixi]] for environment management
 - [[https://github.com/cocogitto/cocogitto][cocogitto]] (=cog=) for conventional commits and changelog
+- [[https://prek.j178.dev][prek]] for git hooks (=prek.toml=)
+- [[https://github.com/lycheeverse/lychee][lychee]] for docs link checks (via =pixi r -e docs linkcheck=)
 
 ** Getting started
 
@@ -21,6 +23,11 @@ pixi r test
 
 # Run with all features (needs capnproto)
 pixi r test-all
+
+# Hooks (prek) and docs
+pixi r prek
+pixi r -e docs docbld
+pixi r -e docs linkcheck
 
 # Build release
 pixi r build
@@ -44,7 +51,10 @@ pixi r -e docs docbld
 * Commit conventions
 
 The project uses [[https://www.conventionalcommits.org/][conventional commits]] enforced by cocogitto.
-The CI lint check rejects non-conforming commit messages.
+The CI lint check rejects non-conforming commit messages on the PR
+range. Some historical commits use =docs+bench:= or untyped merges;
+=cog check --from-latest-tag= is the local equivalent of the PR gate.
+=scripts/release-prep.sh= runs =cog changelog= from the previous tag.
 
 Recognized commit types (from =cog.toml=):
 
@@ -144,11 +154,17 @@ for =cargo build --release= in step 3.
 
 | Workflow | File | Trigger | Purpose |
 |---------------------------+----------------------------+--------------------+--------------------------------------------------|
+| Prek | =ci_prek.yml= | push, PR | =prek run -a= (whitespace, ruff, taplo, codespell) |
+| Documentation | =ci_docs.yml= | push, PR | =pixi r -e docs docbld= then lychee on HTML |
+| C/C++ dist | =ci_cxx.yml= | push, PR | CMake/Meson/pkg-config without cbindgen |
 | Python wheels | =python_wheels.yml= | =v*= tag, PR | Build wheels for 5 platforms, publish to PyPI |
 | Benchmark PR | =ci_benchmark.yml= | PR to main | ASV on base+PR (Python); optional Criterion |
 | Comment benchmark results | =ci_bench_commenter.yml= | benchmark complete | Post ASV/spyglass table as PR comment |
 | Coverage | =coverage.yml= | push, PR | Code coverage via tarpaulin |
-| Lint | =lint.yml= | push, PR | Conventional commit check + large file audit |
+| Lint | =lint.yml= | PR | Conventional commit check + large file audit |
+| Release | =release.yml= | PR plan, =v*= tag | cargo-dist plan on PRs; GitHub Release on tag |
+| crates.io | =crates_publish.yml= | =v*= tag | =cargo publish --locked= |
+| cxx tarball | =cxx_tarball.yml= | GitHub Release | Attach slim + vendor C/C++ source tarballs |
 
 ** Benchmark regression detection
 
@@ -184,28 +200,31 @@ broken (fallback is documented below).
 
 #+begin_example
   scripts/release-prep.sh X.Y.Z
-        │  bumps version files, cog CHANGELOG, cxx-dist gate; cbindgen optional
+        │  prek, pixi docbld + lychee, version bump, cog CHANGELOG,
+        │  cxx-dist gate; cbindgen optional
         ▼
   commit: maint: bump to vX.Y.Z   ──►  open Pull Request to main
         │                                    │
         │                         cargo-dist workflow "Release"
         │                         runs `dist plan` on the PR (validate)
         ▼                                    ▼
-  merge PR to main  ──►  git tag -s vX.Y.Z && git push --tags
+  merge PR to main  ──►  git tag -s vX.Y.Z && git push origin vX.Y.Z
         │
         ├─► workflow "Release" (cargo-dist): CLI archives + GitHub Release
         ├─► workflow "Publish to crates.io": cargo publish --locked
         │         needs repo secret CARGO_REGISTRY_TOKEN
-        └─► workflow "Python wheels": maturin matrix → PyPI (OIDC env `pypi`)
+        ├─► workflow "Python wheels": maturin matrix → PyPI (OIDC env `pypi`)
+        └─► workflow "cxx source tarball": after the GitHub Release exists
 #+end_example
 
 | Layer | What | Workflow / tool |
 |-------+------+-----------------|
-| Prep | Versions + changelog | =scripts/release-prep.sh=, =cog= |
+| Prep | Hooks + docs + versions + changelog | =prek=, =pixi r -e docs docbld=, =lychee=, =scripts/release-prep.sh=, =cog= |
 | Release PR | Validate dist plan before a tag exists | =.github/workflows/release.yml= (cargo-dist; =pr-run-mode = "plan"= in =dist-workspace.toml=) |
 | Tag publish | crates.io | =.github/workflows/crates_publish.yml= |
 | Tag publish | PyPI wheels | =.github/workflows/python_wheels.yml= |
 | Tag publish | GitHub Release + CLI tarballs | same cargo-dist =Release= workflow on the tag |
+| Tag publish | C/C++ source tarballs | =.github/workflows/cxx_tarball.yml= (after the Release exists) |
 
 ** cargo-dist release-PR path
 
@@ -224,7 +243,7 @@ broken (fallback is documented below).
    #+begin_src shell
    git checkout main && git pull origin main
    git tag -s vX.Y.Z -m "vX.Y.Z"
-   git push origin main --tags
+   git push origin vX.Y.Z
    #+end_src
 
 5. On the tag push, the *same* =Release= workflow switches to publishing mode:
@@ -309,6 +328,9 @@ Versions are tracked in six source files that must stay synchronized:
 Fast path (preferred):
 
 #+begin_src shell
+prek run -a
+pixi r -e docs docbld
+pixi r -e docs linkcheck
 scripts/release-prep.sh X.Y.Z
 # review staged files, then:
 git commit -m "maint: bump to vX.Y.Z"
@@ -316,8 +338,8 @@ git commit -m "maint: bump to vX.Y.Z"
 # merge PR to main, then:
 git checkout main && git pull
 git tag -s vX.Y.Z -m "vX.Y.Z"
-git push origin main --tags
-# wait for Release + Publish to crates.io + Python wheels
+git push origin vX.Y.Z
+# wait for Release + Publish to crates.io + Python wheels + cxx tarball
 #+end_src
 
 Manual equivalent of the script:
@@ -328,6 +350,9 @@ Manual equivalent of the script:
    cargo test --locked
    cargo test --locked --features chemfiles   # optional; needs libchemfiles/cmake policy
    pixi r -e python python-test
+   prek run -a
+   pixi r -e docs docbld
+   pixi r -e docs linkcheck
    #+end_src
 
 2. Bump the version in all six files listed above.
@@ -363,7 +388,7 @@ Manual equivalent of the script:
 
    #+begin_src shell
    git tag -s vX.Y.Z -m "vX.Y.Z"
-   git push origin main --tags
+   git push origin vX.Y.Z
    #+end_src
 
 8. Do *not* rely on a local =cargo publish= unless CI is red; prefer

--- a/docs/orgmode/faq.org
+++ b/docs/orgmode/faq.org
@@ -353,4 +353,3 @@ How-to: [[file:migrate.org][migrate.org]], [[file:chemfiles-tutorial.org][chemfi
 Optimizers and drivers are often Fortran or C++. A single =rkr_*= surface
 gives those codes the same CON semantics as Python and Julia without embedding
 a Python interpreter on the I/O path.
-

--- a/docs/scripts/fix_doc_links.py
+++ b/docs/scripts/fix_doc_links.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Rewrite accidental `label <page.rst>`_ links to :doc:`page` in Sphinx RST."""
+
 from __future__ import annotations
 
 import re
@@ -15,7 +16,9 @@ def fix_text(t: str) -> str:
         return f":doc:`{stem}`"
 
     # Relative targets only: absolute URLs (https://.../foo.org) are real links
-    t = re.sub(r"`([^\`<>]+)\s+<((?![a-z][a-z0-9+.-]*:)[^>]+?\.(?:rst|org))>`_", repl, t)
+    t = re.sub(
+        r"`([^\`<>]+)\s+<((?![a-z][a-z0-9+.-]*:)[^>]+?\.(?:rst|org))>`_", repl, t
+    )
     t = re.sub(r"(\S)\./(\s|$)", r"\1.\2", t)
     return t
 

--- a/docs/source/_generated/cachegrind_results.rst
+++ b/docs/source/_generated/cachegrind_results.rst
@@ -50,4 +50,3 @@ Lower is better for the same scenario. Comparable across commits on the same CI 
 
 Wall-clock Criterion tables elsewhere on this page are **illustrative** unless re-run for a release.
 PR workflow **Benchmark PR** still uses Criterion + ``critcmp`` for latency deltas.
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,3 @@
-import os
-
 project = "readcon-core"
 copyright = "2025--present, LODE developers"
 author = "LODE developers"

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -16,6 +16,10 @@ Prerequisites
 
 - `cocogitto <https://github.com/cocogitto/cocogitto>`_ (``cog``) for conventional commits and changelog
 
+- `prek <https://prek.j178.dev>`_ for git hooks (``prek.toml``)
+
+- `lychee <https://github.com/lycheeverse/lychee>`_ for docs link checks (via ``pixi r -e docs linkcheck``)
+
 Getting started
 ~~~~~~~~~~~~~~~
 
@@ -30,6 +34,11 @@ Getting started
 
     # Run with all features (needs capnproto)
     pixi r test-all
+
+    # Hooks (prek) and docs
+    pixi r prek
+    pixi r -e docs docbld
+    pixi r -e docs linkcheck
 
     # Build release
     pixi r build
@@ -54,7 +63,10 @@ Commit conventions
 ------------------
 
 The project uses `conventional commits <https://www.conventionalcommits.org/>`_ enforced by cocogitto.
-The CI lint check rejects non-conforming commit messages.
+The CI lint check rejects non-conforming commit messages on the PR
+range. Some historical commits use ``docs+bench:`` or untyped merges;
+``cog check --from-latest-tag`` is the local equivalent of the PR gate.
+``scripts/release-prep.sh`` runs ``cog changelog`` from the previous tag.
 
 Recognized commit types (from ``cog.toml``):
 
@@ -177,19 +189,31 @@ Workflows
 
 .. table::
 
-    +---------------------------+----------------------------+--------------------+-----------------------------------------------+
-    | Workflow                  | File                       | Trigger            | Purpose                                       |
-    +===========================+============================+====================+===============================================+
-    | Python wheels             | ``python_wheels.yml``      | ``v*`` tag, PR     | Build wheels for 5 platforms, publish to PyPI |
-    +---------------------------+----------------------------+--------------------+-----------------------------------------------+
-    | Benchmark PR              | ``ci_benchmark.yml``       | PR to main         | ASV on base+PR (Python); optional Criterion   |
-    +---------------------------+----------------------------+--------------------+-----------------------------------------------+
-    | Comment benchmark results | ``ci_bench_commenter.yml`` | benchmark complete | Post ASV/spyglass table as PR comment         |
-    +---------------------------+----------------------------+--------------------+-----------------------------------------------+
-    | Coverage                  | ``coverage.yml``           | push, PR           | Code coverage via tarpaulin                   |
-    +---------------------------+----------------------------+--------------------+-----------------------------------------------+
-    | Lint                      | ``lint.yml``               | push, PR           | Conventional commit check + large file audit  |
-    +---------------------------+----------------------------+--------------------+-----------------------------------------------+
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Workflow                  | File                       | Trigger             | Purpose                                              |
+    +===========================+============================+=====================+======================================================+
+    | Prek                      | ``ci_prek.yml``            | push, PR            | ``prek run -a`` (whitespace, ruff, taplo, codespell) |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Documentation             | ``ci_docs.yml``            | push, PR            | ``pixi r -e docs docbld`` then lychee on HTML        |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | C/C++ dist                | ``ci_cxx.yml``             | push, PR            | CMake/Meson/pkg-config without cbindgen              |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Python wheels             | ``python_wheels.yml``      | ``v*`` tag, PR      | Build wheels for 5 platforms, publish to PyPI        |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Benchmark PR              | ``ci_benchmark.yml``       | PR to main          | ASV on base+PR (Python); optional Criterion          |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Comment benchmark results | ``ci_bench_commenter.yml`` | benchmark complete  | Post ASV/spyglass table as PR comment                |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Coverage                  | ``coverage.yml``           | push, PR            | Code coverage via tarpaulin                          |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Lint                      | ``lint.yml``               | PR                  | Conventional commit check + large file audit         |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | Release                   | ``release.yml``            | PR plan, ``v*`` tag | cargo-dist plan on PRs; GitHub Release on tag        |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | crates.io                 | ``crates_publish.yml``     | ``v*`` tag          | ``cargo publish --locked``                           |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
+    | cxx tarball               | ``cxx_tarball.yml``        | GitHub Release      | Attach slim + vendor C/C++ source tarballs           |
+    +---------------------------+----------------------------+---------------------+------------------------------------------------------+
 
 Benchmark regression detection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -229,26 +253,28 @@ Mental model (new contributor)
 ::
 
     scripts/release-prep.sh X.Y.Z
-          │  bumps version files, cog CHANGELOG, cxx-dist gate; cbindgen optional
+          │  prek, pixi docbld + lychee, version bump, cog CHANGELOG,
+          │  cxx-dist gate; cbindgen optional
           ▼
     commit: maint: bump to vX.Y.Z   ──►  open Pull Request to main
           │                                    │
           │                         cargo-dist workflow "Release"
           │                         runs `dist plan` on the PR (validate)
           ▼                                    ▼
-    merge PR to main  ──►  git tag -s vX.Y.Z && git push --tags
+    merge PR to main  ──►  git tag -s vX.Y.Z && git push origin vX.Y.Z
           │
           ├─► workflow "Release" (cargo-dist): CLI archives + GitHub Release
           ├─► workflow "Publish to crates.io": cargo publish --locked
           │         needs repo secret CARGO_REGISTRY_TOKEN
-          └─► workflow "Python wheels": maturin matrix → PyPI (OIDC env `pypi`)
+          ├─► workflow "Python wheels": maturin matrix → PyPI (OIDC env `pypi`)
+          └─► workflow "cxx source tarball": after the GitHub Release exists
 
 .. table::
 
     +-------------+----------------------------------------+-----------------------------------------------------------------------------------------------------+
     | Layer       | What                                   | Workflow / tool                                                                                     |
     +=============+========================================+=====================================================================================================+
-    | Prep        | Versions + changelog                   | ``scripts/release-prep.sh``, ``cog``                                                                |
+    | Prep        | Hooks + docs + versions + changelog    | ``prek``, ``pixi r -e docs docbld``, ``lychee``, ``scripts/release-prep.sh``, ``cog``               |
     +-------------+----------------------------------------+-----------------------------------------------------------------------------------------------------+
     | Release PR  | Validate dist plan before a tag exists | ``.github/workflows/release.yml`` (cargo-dist; ``pr-run-mode = "plan"`` in ``dist-workspace.toml``) |
     +-------------+----------------------------------------+-----------------------------------------------------------------------------------------------------+
@@ -257,6 +283,8 @@ Mental model (new contributor)
     | Tag publish | PyPI wheels                            | ``.github/workflows/python_wheels.yml``                                                             |
     +-------------+----------------------------------------+-----------------------------------------------------------------------------------------------------+
     | Tag publish | GitHub Release + CLI tarballs          | same cargo-dist ``Release`` workflow on the tag                                                     |
+    +-------------+----------------------------------------+-----------------------------------------------------------------------------------------------------+
+    | Tag publish | C/C++ source tarballs                  | ``.github/workflows/cxx_tarball.yml`` (after the Release exists)                                    |
     +-------------+----------------------------------------+-----------------------------------------------------------------------------------------------------+
 
 cargo-dist release-PR path
@@ -281,7 +309,7 @@ cargo-dist release-PR path
 
        git checkout main && git pull origin main
        git tag -s vX.Y.Z -m "vX.Y.Z"
-       git push origin main --tags
+       git push origin vX.Y.Z
 
 5. On the tag push, the **same** ``Release`` workflow switches to publishing mode:
    builds platform archives for the ``readcon-core`` CLI binary and creates (or
@@ -378,6 +406,9 @@ Fast path (preferred):
 
 .. code:: shell
 
+    prek run -a
+    pixi r -e docs docbld
+    pixi r -e docs linkcheck
     scripts/release-prep.sh X.Y.Z
     # review staged files, then:
     git commit -m "maint: bump to vX.Y.Z"
@@ -385,8 +416,8 @@ Fast path (preferred):
     # merge PR to main, then:
     git checkout main && git pull
     git tag -s vX.Y.Z -m "vX.Y.Z"
-    git push origin main --tags
-    # wait for Release + Publish to crates.io + Python wheels
+    git push origin vX.Y.Z
+    # wait for Release + Publish to crates.io + Python wheels + cxx tarball
 
 Manual equivalent of the script:
 
@@ -397,6 +428,9 @@ Manual equivalent of the script:
        cargo test --locked
        cargo test --locked --features chemfiles   # optional; needs libchemfiles/cmake policy
        pixi r -e python python-test
+       prek run -a
+       pixi r -e docs docbld
+       pixi r -e docs linkcheck
 
 2. Bump the version in all six files listed above.
 
@@ -432,7 +466,7 @@ Manual equivalent of the script:
    .. code:: shell
 
        git tag -s vX.Y.Z -m "vX.Y.Z"
-       git push origin main --tags
+       git push origin vX.Y.Z
 
 8. Do **not** rely on a local ``cargo publish`` unless CI is red; prefer
    ``crates_publish.yml`` with ``CARGO_REGISTRY_TOKEN`` set. Local fallback:

--- a/fortran/README.md
+++ b/fortran/README.md
@@ -88,5 +88,5 @@ st = fr%select("name O", nmatch)
 st = fr%select_primary("name H", indices, nwritten)
 ```
 
-C API: `rkr_read_chemfiles_first`, `rkr_read_chemfiles_memory`, `rkr_has_chemfiles_support`.  
+C API: `rkr_read_chemfiles_first`, `rkr_read_chemfiles_memory`, `rkr_has_chemfiles_support`.
 Note: the Fortran **test suite** does not call into chemfiles C++ on CI (SIGFPE traps under gfortran on some runners); chemfiles is covered by Rust CI and the API above remains available for applications.

--- a/include/readcon-core.h
+++ b/include/readcon-core.h
@@ -131,6 +131,20 @@ namespace readcon {
 #define SECTIONS_MASK_ENERGIES (1 << 2)
 
 /**
+ * Reads all frames from a file.
+ *
+ * For files smaller than 64 KiB, uses a simple `read_to_string` to avoid
+ * the fixed overhead of mmap (VMA creation, page fault, munmap). For larger
+ * trajectory files, uses memory-mapped I/O to let the OS page cache handle
+ * the data.
+ * Byte-size gate for Rayon multi-frame parse. Avoids an extra O(n) frame-count
+ * scan: phase-1 of [`parse_frames_parallel`] already walks boundaries when we
+ * choose parallel. Below this size, sequential parse wins on small multi-frame
+ * files (pool scheduling overhead).
+ */
+#define PARALLEL_BYTES_THRESHOLD (48 * 1024)
+
+/**
  * Error codes for RKR functions.
  */
 typedef enum RKRStatus {
@@ -198,10 +212,10 @@ typedef enum RKRStatus {
  * An iterator that lazily parses simulation frames from a `.con` or `.convel`
  * file's contents.
  *
- * This struct wraps an iterator over the lines of a string and, upon each iteration,
- * attempts to parse a complete `ConFrame`. Velocity sections are detected
- * automatically: if a blank line follows the coordinate blocks, the velocity
- * data is parsed into the atoms.
+ * This struct wraps a memchr line cursor over the file buffer and, upon each
+ * iteration, attempts to parse a complete `ConFrame`. Velocity sections are
+ * detected automatically: if a blank line follows the coordinate blocks, the
+ * velocity data is parsed into the atoms.
  *
  * The iterator yields items of type `Result<ConFrame, ParseError>`, allowing for
  * robust error handling for each frame.

--- a/lychee.toml
+++ b/lychee.toml
@@ -34,7 +34,4 @@ exclude = [
 
 
 # Do not require network for scheme-less / data
-exclude_path = [
-  "docs/build/_static/.*",
-  "docs/build/searchindex.js",
-]
+exclude_path = ["docs/build/_static/.*", "docs/build/searchindex.js"]

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,8 @@ pkg.generate(
     filebase: 'readcon-core',
     description: 'CON/convel file reader and writer with FFI, Python, Julia bindings',
     version: meson.project_version(),
-    libraries: ['-lreadcon_core'],
+    # Raw `-lfoo` strings do not get `-L${libdir}`; wrap consumers then
+    # fail at link with "cannot find -lreadcon_core".
+    libraries: ['-L${libdir}', '-lreadcon_core'],
     url: 'https://github.com/lode-org/readcon-core',
 )

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,6 +16,8 @@ regen-capi-headers = { cmd = "scripts/regen-capi-headers.sh", description = "Reg
 check-capi-headers = { cmd = "scripts/regen-capi-headers.sh --check", description = "Verify shipped C header matches what cbindgen would produce" }
 check-cxx-dist = { cmd = "scripts/check-cxx-dist.sh", description = "Gate: CMake/Meson/pkg-config never require cbindgen" }
 package-cxx = { cmd = "scripts/package-cxx.sh dist-cxx", description = "Assemble readcon-core-cxx-$VERSION.tar.gz" }
+prek = { cmd = "prek run -a", description = "Run prek hooks on all files" }
+prek-install = { cmd = "prek install", description = "Install prek git hooks in this checkout" }
 
 [dependencies]
 rust = ">=1.88"
@@ -23,7 +25,13 @@ capnproto = "*"
 
 [feature.python]
 dependencies = { python = ">=3.10", maturin = ">=1.5", pytest = "*", pip = "*", numpy = ">=1.22" }
-tasks = { python-build = "maturin develop --features python", python-build-chemfiles = "maturin develop --features python,chemfiles", python-test = { cmd = "pytest tests/python/", depends-on = ["python-build"] }, chemfiles-notebook = { cmd = "scripts/run-chemfiles-notebook.sh", depends-on = ["python-build-chemfiles"], description = "Org Babel executable chemfiles→CON tutorial" }, tutorial-core = { cmd = "scripts/run-tutorial-core.sh", depends-on = ["python-build"], description = "Org Babel One Good Tutorial (CON checkpoint)" } }
+tasks = { python-build = "maturin develop --features python", python-build-chemfiles = "maturin develop --features python,chemfiles", python-test = { cmd = "pytest tests/python/", depends-on = [
+  "python-build",
+] }, chemfiles-notebook = { cmd = "scripts/run-chemfiles-notebook.sh", depends-on = [
+  "python-build-chemfiles",
+], description = "Org Babel executable chemfiles→CON tutorial" }, tutorial-core = { cmd = "scripts/run-tutorial-core.sh", depends-on = [
+  "python-build",
+], description = "Org Babel One Good Tutorial (CON checkpoint)" } }
 
 [feature.julia]
 platforms = ["linux-64"]
@@ -42,11 +50,20 @@ myst-parser = ">=4.0, <5"
 sphinxcontrib-mermaid = ">=1.0, <2"
 [feature.docs.tasks]
 setup-rustdocgen = { cmd = "cargo install sphinx-rustdocgen", description = "Install sphinx-rustdocgen for Rust API docs" }
-docbld-full = { cmd = "sphinx-build docs/source docs/build -b html", depends-on = ["orgbld", "setup-rustdocgen"], description = "Docs including fresh rustdocgen" }
+docbld-full = { cmd = "sphinx-build docs/source docs/build -b html", depends-on = [
+  "orgbld",
+  "setup-rustdocgen",
+], description = "Docs including fresh rustdocgen" }
 orgbld = "emacs --batch -l docs/export.el"
-fix-doc-links = { cmd = "python docs/scripts/fix_doc_links.py", depends-on = ["orgbld"], description = "Rewrite .rst hyperlinks to :doc: roles" }
-docbld = { cmd = "sphinx-build docs/source docs/build -b html", depends-on = ["fix-doc-links"] }
-linkcheck = { cmd = "lychee --config lychee.toml 'docs/build/**/*.html'", depends-on = ["docbld"], description = "Lychee link check on built HTML" }
+fix-doc-links = { cmd = "python docs/scripts/fix_doc_links.py", depends-on = [
+  "orgbld",
+], description = "Rewrite .rst hyperlinks to :doc: roles" }
+docbld = { cmd = "sphinx-build docs/source docs/build -b html", depends-on = [
+  "fix-doc-links",
+] }
+linkcheck = { cmd = "lychee --config lychee.toml 'docs/build/**/*.html'", depends-on = [
+  "docbld",
+], description = "Lychee link check on built HTML" }
 
 [environments]
 default = { solve-group = "default" }

--- a/prek.toml
+++ b/prek.toml
@@ -52,18 +52,10 @@ hooks = [
 [[repos]]
 repo = "https://github.com/ComPWA/taplo-pre-commit"
 rev = "v0.9.3"
-hooks = [{ id = "taplo-format" }]
+# prek.toml uses multiline inline tables; taplo 0.9 rejects those as invalid.
+hooks = [{ id = "taplo-format", exclude = "^prek\\.toml$" }]
 
 [[repos]]
 repo = "https://github.com/codespell-project/codespell"
 rev = "v2.4.1"
-hooks = [
-  {
-    id = "codespell",
-    args = [
-      "--skip=*.lock,*.svg,*.con,*.convel,*.json,*.html,*.bib,*.f90,docs/build,docs/_build,docs/source/crates",
-      "-L",
-      "crate,crates,nd,te,TE,ans,ro,RO,wit,inout,dum,fiter,implementors,implementor",
-    ],
-  },
-]
+hooks = [{ id = "codespell", args = ["--skip=*.lock,*.svg,*.con,*.convel,*.json,*.html,*.bib,*.f90,docs/build,docs/_build,docs/source/crates", "-L", "crate,crates,nd,te,TE,ans,ro,RO,wit,inout,dum,fiter,implementors,implementor"] }]

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,69 @@
+# Git hooks via `prek` (https://prek.j178.dev).
+# Install: `prek install`  (or `pixi r prek-install`)
+# Run all: `prek run -a`   (or `pixi r prek`)
+#:schema https://www.schemastore.org/prek.json
+
+minimum_prek_version = "0.3.0"
+
+exclude = """(?x)(
+    ^\\.pixi/|
+    ^docs/build/|
+    ^docs/_build/|
+    ^docs/source/crates/|
+    ^docs/notebooks/|
+    ^fortran/.*/build/|
+    ^benches/|
+    ^resources/test/|
+    ^.*\\.svg$|
+    ^.*\\.lock$
+)"""
+
+# Fast native implementations (no clone / no Python env).
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "trailing-whitespace" },
+  { id = "end-of-file-fixer" },
+  { id = "check-yaml" },
+  { id = "check-toml" },
+  { id = "check-merge-conflict" },
+  { id = "check-added-large-files", args = ["--maxkb=1000"] },
+  { id = "check-case-conflict" },
+  { id = "detect-private-key" },
+  { id = "mixed-line-ending", args = ["--fix=lf"] },
+]
+
+[[repos]]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+hooks = [
+  { id = "check-ast" },
+  { id = "debug-statements" },
+]
+
+[[repos]]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.15.2"
+hooks = [
+  { id = "ruff", args = ["--fix"], types_or = ["python"] },
+  { id = "ruff-format", types_or = ["python"] },
+]
+
+[[repos]]
+repo = "https://github.com/ComPWA/taplo-pre-commit"
+rev = "v0.9.3"
+hooks = [{ id = "taplo-format" }]
+
+[[repos]]
+repo = "https://github.com/codespell-project/codespell"
+rev = "v2.4.1"
+hooks = [
+  {
+    id = "codespell",
+    args = [
+      "--skip=*.lock,*.svg,*.con,*.convel,*.json,*.html,*.bib,*.f90,docs/build,docs/_build,docs/source/crates",
+      "-L",
+      "crate,crates,nd,te,TE,ans,ro,RO,wit,inout,dum,fiter,implementors,implementor",
+    ],
+  },
+]

--- a/pyproject.chemfiles.toml
+++ b/pyproject.chemfiles.toml
@@ -11,12 +11,12 @@ license = "MIT"
 readme = "README.md"
 keywords = ["parser", "comp-chem", "file-format", "con", "eon", "chemfiles"]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Chemistry",
-    "Topic :: Scientific/Engineering :: Physics",
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Chemistry",
+  "Topic :: Scientific/Engineering :: Physics",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ license = "MIT"
 readme = "README.md"
 keywords = ["parser", "comp-chem", "file-format", "con", "eon"]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Science/Research",
-    "Topic :: Scientific/Engineering :: Chemistry",
-    "Topic :: Scientific/Engineering :: Physics",
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Chemistry",
+  "Topic :: Scientific/Engineering :: Physics",
+  "Programming Language :: Rust",
+  "Programming Language :: Python :: Implementation :: CPython",
 ]
 
 [project.urls]
@@ -41,3 +41,7 @@ chemfiles = ["readcon-chemfiles==0.14.1"]
 # `python` pulls `parallel` (Rayon multi-frame parse) via Cargo.toml.
 features = ["python"]
 module-name = "readcon"
+
+[tool.ruff.lint]
+# pytest.importorskip must run before the imported name is used.
+per-file-ignores = { "tests/**/*.py" = ["E402"] }

--- a/scripts/meson_cargo_build.py
+++ b/scripts/meson_cargo_build.py
@@ -3,6 +3,7 @@
 
 Used by meson.build. Headers are shipped; this script never invokes cbindgen.
 """
+
 from __future__ import annotations
 
 import os

--- a/scripts/package-cxx.sh
+++ b/scripts/package-cxx.sh
@@ -55,6 +55,8 @@ tar -C "${TMP_DIR}/crate" -xf "$CRATE_TAR"
 CRATE_DIR="$(find "${TMP_DIR}/crate" -mindepth 1 -maxdepth 1 -type d | head -1)"
 
 cp -a "${CRATE_DIR}/." "$DEST/"
+# Maintainer-only; the tarball ships include/ and must not look cbindgen-gated.
+rm -f "$DEST/cbindgen.toml"
 
 # Overlay the C/C++ distribution files (always, even if cargo package omitted them).
 cp -a "$ROOT_DIR/CMakeLists.txt" "$DEST/"

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Prepare a release commit per docs/orgmode/contributing.org (items 1–6).
+# Prepare a release commit per docs/orgmode/contributing.org.
 # Usage: scripts/release-prep.sh X.Y.Z
+# Requires: cog, prek, pixi (docs env), lychee. cargo test unless
+# READCON_RELEASE_PREP_SKIP_TESTS=1 (run tests on the remote builder).
 # Then open a PR (cargo-dist Release workflow runs plan on PRs), merge,
-# and: git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin main --tags
+# and: git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
@@ -13,8 +15,19 @@ if ! [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
   exit 1
 fi
 
-echo "==> tests (default features)"
-cargo test --locked
+for cmd in cog prek pixi lychee; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd required on PATH" >&2
+    exit 1
+  fi
+done
+
+if [[ "${READCON_RELEASE_PREP_SKIP_TESTS:-}" == 1 ]]; then
+  echo "==> tests skipped (READCON_RELEASE_PREP_SKIP_TESTS=1)"
+else
+  echo "==> tests (default features)"
+  cargo test --locked
+fi
 
 echo "==> version bump -> $VER"
 # Cargo.toml package version (first occurrence)
@@ -32,18 +45,31 @@ sed -i "s/^version = \".*\"/version = \"${VER}\"/" fortran/ReadCon/fpm.toml
 sed -i "s/^version: .*/version: ${VER}/" CITATION.cff
 
 echo "==> Cargo.lock refresh"
-cargo test --locked -q
+if [[ "${READCON_RELEASE_PREP_SKIP_TESTS:-}" == 1 ]]; then
+  echo "skipping cargo test --locked; refresh Cargo.lock on the builder"
+else
+  cargo test --locked -q
+fi
 
 echo "==> CHANGELOG via cog"
-if ! command -v cog >/dev/null 2>&1; then
-  echo "cog (cocogitto) required on PATH" >&2
-  exit 1
-fi
+# Full-history `cog changelog` fails on pre-v0.14 commits whose types
+# are not conventional (`docs+bench:`, untyped merges). Generate the
+# new section from the previous tag and keep existing ## v* sections.
+prev="$(git describe --tags --abbrev=0)"
 {
   sed -n '1,3p' CHANGELOG.md
-  cog changelog
+  cog changelog "${prev}.."
+  echo
+  awk '/^## v/{found=1} found' CHANGELOG.md
 } > /tmp/CHANGELOG.md
 mv /tmp/CHANGELOG.md CHANGELOG.md
+
+echo "==> prek"
+prek run -a
+
+echo "==> docs (orgbld + sphinx) and lychee"
+pixi r -e docs docbld
+pixi r -e docs linkcheck
 
 echo "==> C/C++ distribution gate (no cbindgen required)"
 scripts/check-cxx-dist.sh
@@ -65,7 +91,7 @@ echo "  git commit -m \"maint: bump to v${VER}\""
 echo "  # open PR so .github/workflows/release.yml runs dist plan"
 echo "  # after merge:"
 echo "  git tag -s v${VER} -m \"v${VER}\""
-echo "  git push origin main --tags"
+echo "  git push origin v${VER}"
 echo "  # crates_publish.yml + python_wheels.yml + cargo-dist Release + cxx_tarball.yml"
 echo "  # After the tag: scripts/package-cxx.sh dist/ --vendor"
 echo "  # Attach readcon-core-cxx-${VER}.tar.gz to the GitHub Release (cxx_tarball.yml)"

--- a/scripts/render_cachegrind_rst.py
+++ b/scripts/render_cachegrind_rst.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Render docs/source/_generated/cachegrind_results.rst from JSON."""
+
 from __future__ import annotations
 
 import json
@@ -46,7 +47,9 @@ def main() -> int:
     for name, irefs in scenarios.items():
         note = NOTES.get(name, "")
         lines.append(f"   * - ``{name}``")
-        lines.append(f"     - {irefs:,}" if isinstance(irefs, int) else f"     - {irefs}")
+        lines.append(
+            f"     - {irefs:,}" if isinstance(irefs, int) else f"     - {irefs}"
+        )
         lines.append(f"     - {note}")
     feat = data.get("features", "")
     lines += [

--- a/scripts/rewrite_julia_lcov.py
+++ b/scripts/rewrite_julia_lcov.py
@@ -4,6 +4,7 @@
 Coverage.jl emits package-relative paths (src/wrapper.jl). Codecov flag
 paths are julia/ReadCon/src/**, so map SF records to absolute workspace paths.
 """
+
 from __future__ import annotations
 
 import argparse

--- a/src/python.rs
+++ b/src/python.rs
@@ -1762,4 +1762,3 @@ fn select_atom_positions_on_frames(
     let multi = rust_sel(selection, &rust_frames).map_err(chemfiles_err_to_py)?;
     multi_frame_selection_to_py(py, multi)
 }
-

--- a/tests/python/test_ase.py
+++ b/tests/python/test_ase.py
@@ -40,23 +40,26 @@ class TestAseAtomId:
         assert roundtrip_ids == original_ids
 
     def test_from_ase_falls_back_to_tags(self):
-        atoms = ase.Atoms("CuH", positions=[[0, 0, 0], [1, 1, 1]],
-                          cell=[10, 10, 10], pbc=True)
+        atoms = ase.Atoms(
+            "CuH", positions=[[0, 0, 0], [1, 1, 1]], cell=[10, 10, 10], pbc=True
+        )
         atoms.set_tags([42, 7])
         frame = readcon.ConFrame.from_ase(atoms)
         assert frame.atoms[0].atom_id == 42
         assert frame.atoms[1].atom_id == 7
 
     def test_from_ase_falls_back_to_sequential(self):
-        atoms = ase.Atoms("CuH", positions=[[0, 0, 0], [1, 1, 1]],
-                          cell=[10, 10, 10], pbc=True)
+        atoms = ase.Atoms(
+            "CuH", positions=[[0, 0, 0], [1, 1, 1]], cell=[10, 10, 10], pbc=True
+        )
         frame = readcon.ConFrame.from_ase(atoms)
         assert frame.atoms[0].atom_id == 0
         assert frame.atoms[1].atom_id == 1
 
     def test_from_ase_prefers_atom_id_over_tags(self):
-        atoms = ase.Atoms("CuH", positions=[[0, 0, 0], [1, 1, 1]],
-                          cell=[10, 10, 10], pbc=True)
+        atoms = ase.Atoms(
+            "CuH", positions=[[0, 0, 0], [1, 1, 1]], cell=[10, 10, 10], pbc=True
+        )
         atoms.set_tags([99, 99])
         atoms.set_array("atom_id", np.array([10, 20]))
         frame = readcon.ConFrame.from_ase(atoms)
@@ -65,10 +68,24 @@ class TestAseAtomId:
 
     def test_nonsequential_atom_id_roundtrip(self):
         atoms_list = [
-            readcon.Atom(symbol="Cu", x=0.0, y=0.0, z=0.0,
-                         fixed=[True, True, True], atom_id=3, mass=63.546),
-            readcon.Atom(symbol="H", x=1.0, y=2.0, z=3.0,
-                         fixed=[False, False, False], atom_id=1, mass=1.008),
+            readcon.Atom(
+                symbol="Cu",
+                x=0.0,
+                y=0.0,
+                z=0.0,
+                fixed=[True, True, True],
+                atom_id=3,
+                mass=63.546,
+            ),
+            readcon.Atom(
+                symbol="H",
+                x=1.0,
+                y=2.0,
+                z=3.0,
+                fixed=[False, False, False],
+                atom_id=1,
+                mass=1.008,
+            ),
         ]
         frame = readcon.ConFrame(
             cell=[10.0, 10.0, 10.0],
@@ -115,8 +132,9 @@ class TestAseVelocities:
             assert back.vz == pytest.approx(orig.vz, abs=1e-8)
 
     def test_from_ase_with_velocities(self):
-        atoms = ase.Atoms("CuH", positions=[[0, 0, 0], [1, 1, 1]],
-                          cell=[10, 10, 10], pbc=True)
+        atoms = ase.Atoms(
+            "CuH", positions=[[0, 0, 0], [1, 1, 1]], cell=[10, 10, 10], pbc=True
+        )
         atoms.set_velocities([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
         frame = readcon.ConFrame.from_ase(atoms)
         assert frame.has_velocities
@@ -124,8 +142,9 @@ class TestAseVelocities:
         assert frame.atoms[1].vz == pytest.approx(0.6)
 
     def test_from_ase_no_velocities(self):
-        atoms = ase.Atoms("CuH", positions=[[0, 0, 0], [1, 1, 1]],
-                          cell=[10, 10, 10], pbc=True)
+        atoms = ase.Atoms(
+            "CuH", positions=[[0, 0, 0], [1, 1, 1]], cell=[10, 10, 10], pbc=True
+        )
         frame = readcon.ConFrame.from_ase(atoms)
         assert not frame.has_velocities
         assert frame.atoms[0].vx is None
@@ -143,8 +162,7 @@ class TestAseMasses:
 
     def test_mass_roundtrip_via_ase(self):
         atoms_list = [
-            readcon.Atom(symbol="Pt", x=0.0, y=0.0, z=0.0,
-                         mass=195.08, atom_id=0),
+            readcon.Atom(symbol="Pt", x=0.0, y=0.0, z=0.0, mass=195.08, atom_id=0),
         ]
         frame = readcon.ConFrame(
             cell=[10.0, 10.0, 10.0],
@@ -184,20 +202,29 @@ class TestAseConstraints:
             cell=[10.0, 10.0, 10.0],
             angles=[90.0, 90.0, 90.0],
             atoms=[
-                readcon.Atom(symbol="Cu", x=0.0, y=0.0, z=0.0,
-                             fixed=[True, False, True], atom_id=0),
-                readcon.Atom(symbol="H", x=1.0, y=1.0, z=1.0,
-                             fixed=[True, True, True], atom_id=1),
+                readcon.Atom(
+                    symbol="Cu",
+                    x=0.0,
+                    y=0.0,
+                    z=0.0,
+                    fixed=[True, False, True],
+                    atom_id=0,
+                ),
+                readcon.Atom(
+                    symbol="H", x=1.0, y=1.0, z=1.0, fixed=[True, True, True], atom_id=1
+                ),
             ],
         )
 
         ase_atoms = frame.to_ase()
         fix_cartesian = [
-            constraint for constraint in ase_atoms.constraints
+            constraint
+            for constraint in ase_atoms.constraints
             if constraint.__class__.__name__ == "FixCartesian"
         ]
         fix_atoms = [
-            constraint for constraint in ase_atoms.constraints
+            constraint
+            for constraint in ase_atoms.constraints
             if constraint.__class__.__name__ == "FixAtoms"
         ]
 
@@ -212,12 +239,25 @@ class TestAseConstraints:
             cell=[10.0, 10.0, 10.0],
             angles=[90.0, 90.0, 90.0],
             atoms=[
-                readcon.Atom(symbol="Cu", x=0.0, y=0.0, z=0.0,
-                             fixed=[True, False, True], atom_id=0),
-                readcon.Atom(symbol="H", x=1.0, y=1.0, z=1.0,
-                             fixed=[False, True, False], atom_id=1),
-                readcon.Atom(symbol="H", x=2.0, y=2.0, z=2.0,
-                             fixed=[True, True, True], atom_id=2),
+                readcon.Atom(
+                    symbol="Cu",
+                    x=0.0,
+                    y=0.0,
+                    z=0.0,
+                    fixed=[True, False, True],
+                    atom_id=0,
+                ),
+                readcon.Atom(
+                    symbol="H",
+                    x=1.0,
+                    y=1.0,
+                    z=1.0,
+                    fixed=[False, True, False],
+                    atom_id=1,
+                ),
+                readcon.Atom(
+                    symbol="H", x=2.0, y=2.0, z=2.0, fixed=[True, True, True], atom_id=2
+                ),
             ],
         )
 

--- a/tests/python/test_chemfiles_import.py
+++ b/tests/python/test_chemfiles_import.py
@@ -51,9 +51,15 @@ def test_read_chemfiles_all_and_memory(water_xyz: Path):
 
 def test_select_methods_on_frame_with_bonds():
     atoms = [
-        readcon.Atom("O", 0.0, 0.0, 0.0, fixed=[False, False, False], atom_id=0, mass=16.0),
-        readcon.Atom("H", 1.0, 0.0, 0.0, fixed=[False, False, False], atom_id=1, mass=1.0),
-        readcon.Atom("H", 0.0, 1.0, 0.0, fixed=[False, False, False], atom_id=2, mass=1.0),
+        readcon.Atom(
+            "O", 0.0, 0.0, 0.0, fixed=[False, False, False], atom_id=0, mass=16.0
+        ),
+        readcon.Atom(
+            "H", 1.0, 0.0, 0.0, fixed=[False, False, False], atom_id=1, mass=1.0
+        ),
+        readcon.Atom(
+            "H", 0.0, 1.0, 0.0, fixed=[False, False, False], atom_id=2, mass=1.0
+        ),
     ]
     frame = readcon.ConFrame(
         cell=[10.0, 10.0, 10.0],

--- a/tests/python/test_chemfiles_selection.py
+++ b/tests/python/test_chemfiles_selection.py
@@ -28,9 +28,33 @@ _TINY_MULTI = _REPO / "resources" / "test" / "tiny_multi_cuh2.con"
 def _ho_frame():
     """CON atom_data order: species are contiguous (H then O), not interleaved."""
     atoms = [
-        readcon.Atom(symbol="H", x=0.0, y=0.0, z=0.0, fixed=[False, False, False], atom_id=0, mass=1.0),
-        readcon.Atom(symbol="H", x=2.0, y=0.0, z=0.0, fixed=[False, False, False], atom_id=1, mass=1.0),
-        readcon.Atom(symbol="O", x=1.0, y=0.0, z=0.0, fixed=[False, False, False], atom_id=2, mass=16.0),
+        readcon.Atom(
+            symbol="H",
+            x=0.0,
+            y=0.0,
+            z=0.0,
+            fixed=[False, False, False],
+            atom_id=0,
+            mass=1.0,
+        ),
+        readcon.Atom(
+            symbol="H",
+            x=2.0,
+            y=0.0,
+            z=0.0,
+            fixed=[False, False, False],
+            atom_id=1,
+            mass=1.0,
+        ),
+        readcon.Atom(
+            symbol="O",
+            x=1.0,
+            y=0.0,
+            z=0.0,
+            fixed=[False, False, False],
+            atom_id=2,
+            mass=16.0,
+        ),
     ]
     return readcon.ConFrame(
         cell=[10.0, 10.0, 10.0],

--- a/tests/python/test_index_proj.py
+++ b/tests/python/test_index_proj.py
@@ -1,4 +1,5 @@
 """Drive shipped PyO3 entry points for campaign index_proj + canonical writer."""
+
 import os
 import tempfile
 

--- a/tests/python/test_readcon.py
+++ b/tests/python/test_readcon.py
@@ -144,9 +144,33 @@ class TestAtomConstructor:
 class TestConFrameConstructor:
     def test_build_frame(self):
         atoms = [
-            readcon.Atom(symbol="Cu", x=0.0, y=0.0, z=0.0, fixed=[True, True, True], atom_id=0, mass=63.546),
-            readcon.Atom(symbol="Cu", x=1.0, y=1.0, z=1.0, fixed=[True, True, True], atom_id=1, mass=63.546),
-            readcon.Atom(symbol="H", x=2.0, y=2.0, z=2.0, fixed=[False, False, False], atom_id=2, mass=1.008),
+            readcon.Atom(
+                symbol="Cu",
+                x=0.0,
+                y=0.0,
+                z=0.0,
+                fixed=[True, True, True],
+                atom_id=0,
+                mass=63.546,
+            ),
+            readcon.Atom(
+                symbol="Cu",
+                x=1.0,
+                y=1.0,
+                z=1.0,
+                fixed=[True, True, True],
+                atom_id=1,
+                mass=63.546,
+            ),
+            readcon.Atom(
+                symbol="H",
+                x=2.0,
+                y=2.0,
+                z=2.0,
+                fixed=[False, False, False],
+                atom_id=2,
+                mass=1.008,
+            ),
         ]
         frame = readcon.ConFrame(
             cell=[10.0, 10.0, 10.0],
@@ -161,10 +185,24 @@ class TestConFrameConstructor:
 
     def test_roundtrip(self):
         atoms = [
-            readcon.Atom(symbol="Cu", x=0.123456789012345, y=0.0, z=0.0,
-                         fixed=[True, True, True], atom_id=0, mass=63.546),
-            readcon.Atom(symbol="H", x=1.0, y=2.0, z=3.0,
-                         fixed=[False, False, False], atom_id=1, mass=1.008),
+            readcon.Atom(
+                symbol="Cu",
+                x=0.123456789012345,
+                y=0.0,
+                z=0.0,
+                fixed=[True, True, True],
+                atom_id=0,
+                mass=63.546,
+            ),
+            readcon.Atom(
+                symbol="H",
+                x=1.0,
+                y=2.0,
+                z=3.0,
+                fixed=[False, False, False],
+                atom_id=1,
+                mass=1.008,
+            ),
         ]
         frame = readcon.ConFrame(
             cell=[15.0, 15.0, 100.0],
@@ -298,12 +336,18 @@ class TestConFrameConstructor:
         frame = readcon.ConFrame(
             cell=[10.0, 10.0, 10.0],
             angles=[90.0, 90.0, 90.0],
-            atoms=[readcon.Atom(symbol="H", x=0.0, y=0.0, z=0.0, atom_id=0, mass=1.008)],
+            atoms=[
+                readcon.Atom(symbol="H", x=0.0, y=0.0, z=0.0, atom_id=0, mass=1.008)
+            ],
         )
 
         atoms = frame.atoms
-        atoms.append(readcon.Atom(symbol="Cu", x=1.0, y=1.0, z=1.0, atom_id=1, mass=63.546))
-        atoms[0] = readcon.Atom(symbol="He", x=2.0, y=2.0, z=2.0, atom_id=0, mass=4.0026)
+        atoms.append(
+            readcon.Atom(symbol="Cu", x=1.0, y=1.0, z=1.0, atom_id=1, mass=63.546)
+        )
+        atoms[0] = readcon.Atom(
+            symbol="He", x=2.0, y=2.0, z=2.0, atom_id=0, mass=4.0026
+        )
         atoms[1].x = 4.5
 
         reread = readcon.read_con_string(readcon.write_con_string([frame]))[0]
@@ -428,7 +472,7 @@ class TestNumpyArrays:
         assert frame.velocities_array() is None
 
     def test_forces_array_round_trips(self):
-        np = pytest.importorskip("numpy")
+        pytest.importorskip("numpy")
         frame = readcon.read_con(_resource("tiny_cuh2_forces.con"))[0]
         forces = frame.forces_array()
         assert forces is not None
@@ -465,6 +509,7 @@ class TestErrorHandling:
 def test_read_all_frames_matches_read_con():
     """Batch ergonomics alias must match read_con on a real fixture."""
     from pathlib import Path
+
     tiny = Path(__file__).resolve().parents[2] / "resources" / "test" / "tiny_cuh2.con"
     a = readcon.read_con(str(tiny))
     b = readcon.read_all_frames(str(tiny))

--- a/tests/python/test_tutorial_chemfiles.py
+++ b/tests/python/test_tutorial_chemfiles.py
@@ -53,7 +53,10 @@ def test_chemfiles_notebook_org_declares_tangle():
     assert "tangle drift" in script
     assert "falling back" not in script
     # no soft-success paths (git-diff may use ``|| true`` only to print under set -e)
-    assert "papermill" not in script or "|| true" not in script.split("papermill")[-1][:200]
+    assert (
+        "papermill" not in script
+        or "|| true" not in script.split("papermill")[-1][:200]
+    )
     assert "missing after babel; trying tangled" not in script
 
 

--- a/tests/python/test_tutorial_core.py
+++ b/tests/python/test_tutorial_core.py
@@ -47,7 +47,7 @@ def test_org_source_declares_tangle_and_ci_script():
     script = SCRIPT.read_text(encoding="utf-8")
     assert "tangle drift" in script
     assert "falling back" not in script
-    assert "python3 \"$TANGLE_PY\"" in script or 'python3 "$TANGLE_PY"' in script
+    assert 'python3 "$TANGLE_PY"' in script or 'python3 "$TANGLE_PY"' in script
 
 
 def test_org_babel_tutorial_core_script():


### PR DESCRIPTION
Add the missing hook and docs gates to the release path.

- `prek.toml` + `ci_prek.yml`
- `release-prep.sh` runs prek, orgbld/sphinx, and lychee
- Changelog via `cog changelog` from the previous tag
- Push only `vX.Y.Z` (do not push every local tag)

Local: `prek run -a` green, `cog check --from-latest-tag` green, lychee 0 errors on built HTML.