### PR TITLE
feat(rpc): ABI minor reject, Unix endpoints, and RCSO pack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,10 @@ name = "rust_usage"
 name = "wall_scale_harness"
 required-features = ["parallel"]
 
+[[example]]
+name = "leaf_io_harness"
+required-features = ["rpc"]
+
 [[bench]]
 name = "iterator_bench"
 harness = false

--- a/benches/results/leaf_io.json
+++ b/benches/results/leaf_io.json
@@ -1,0 +1,22 @@
+{
+  "protocol": "cuh2.con x100: CON parse vs RCSO encode/decode; one-frame RpcClient parse_bytes Unix vs TCP loopback",
+  "host": "rgam5terra",
+  "date_utc": "2026-08-24T13:01Z",
+  "commit": "9b94ca5c",
+  "features": "rpc",
+  "ncpus": 32,
+  "n_frames": 100,
+  "n_atoms": 218,
+  "repeats": 5,
+  "fixture": "resources/test/cuh2.con",
+  "payload_bytes": 1677100,
+  "one_frame_bytes": 16771,
+  "rcsb_bytes": 526012,
+  "parse_100_frames_ms": 2.680600,
+  "rcso_pack_100_ms": 0.206410,
+  "rcso_decode_100_ms": 0.028133,
+  "parse_over_decode": 95.2831,
+  "rpc_unix_one_frame_ms": 0.078478,
+  "rpc_tcp_one_frame_ms": 0.138462,
+  "tcp_over_unix": 1.7643
+}

--- a/docs/orgmode/rpc.org
+++ b/docs/orgmode/rpc.org
@@ -72,6 +72,25 @@ let output = client.write_frames(&frames).unwrap();
 
 * Protocol
 
-The RPC uses Cap'n Proto two-party protocol over TCP. The server
-listens on a configurable host:port and handles one connection per
-accepted socket using tokio for async I/O.
+The RPC uses Cap'n Proto two-party as the *encoding*. The byte pipe is
+not UCX, libfabric, Mercury, or ADIOS.
+
+| Spec | Pipe |
+|------|------|
+| =host:port= or =[ipv6]:port= | TCP |
+| =unix:/abs/path=, =unix:///abs/path=, or =/abs/path= | Unix domain socket |
+
+Same-node HPC jobs should use a Unix socket (no TCP loopback). TCP is
+for inet. UCX/ADIOS/DAOS are optional later adapters if a campaign
+consumer exists; they are not this crate and they are not the CON
+store. Corpus I/O decisions live in the readcon-db 2026-08-23
+exascale I/O literature note (ADIOS2/DAOS/SST move GB-class arrays;
+they do not replace a FrameKey mmap of CON).
+
+#+begin_src rust
+readcon_core::rpc::server::start_server("unix:/tmp/readcon.sock")
+#+end_src
+
+#+begin_src rust
+let client = RpcClient::new("unix:/tmp/readcon.sock").unwrap();
+#+end_src

--- a/docs/orgmode/rpc.org
+++ b/docs/orgmode/rpc.org
@@ -87,6 +87,11 @@ store. Corpus I/O decisions live in the readcon-db 2026-08-23
 exascale I/O literature note (ADIOS2/DAOS/SST move GB-class arrays;
 they do not replace a FrameKey mmap of CON).
 
+The MD-engine leaf is pack-then-Bcast on the *caller* comm. Encode a
+parsed frame with =readcon_core::rcso::Rcso::encode_frame= (magic
+=RCSO=, v1, same bytes as readcon-db cooked SoA). Many frames go in
+one =RCSB= envelope. This crate never calls =MPI_Init=.
+
 #+begin_src rust
 readcon_core::rpc::server::start_server("unix:/tmp/readcon.sock")
 #+end_src

--- a/docs/source/rpc.rst
+++ b/docs/source/rpc.rst
@@ -95,6 +95,18 @@ Client
 Protocol
 --------
 
-The RPC uses Cap'n Proto two-party protocol over TCP. The server
-listens on a configurable host:port and handles one connection per
-accepted socket using tokio for async I/O.
+The RPC uses Cap'n Proto two-party as the encoding. The byte pipe is
+not UCX, libfabric, Mercury, or ADIOS.
+
+- ``host:port`` or ``[ipv6]:port`` is TCP.
+- ``unix:/abs/path``, ``unix:///abs/path``, or ``/abs/path`` is a Unix
+  domain socket.
+
+Same-node HPC jobs should use a Unix socket. TCP is for inet. UCX,
+ADIOS, and DAOS are optional later adapters if a campaign consumer
+exists; they are not this crate and they are not the CON store.
+
+.. code:: rust
+
+    readcon_core::rpc::server::start_server("unix:/tmp/readcon.sock")
+    let client = RpcClient::new("unix:/tmp/readcon.sock").unwrap();

--- a/examples/leaf_io_harness.rs
+++ b/examples/leaf_io_harness.rs
@@ -1,0 +1,234 @@
+//! Wall times for the leaf I/O contract: parse CON vs decode RCSO, Unix vs TCP RPC.
+//!
+//! Usage (builder only):
+//!
+//! ```text
+//! cargo run --release --example leaf_io_harness --features rpc -- \
+//!     benches/results/leaf_io.json
+//! ```
+//!
+//! Same fixture and repeat count as `wall_scale_harness`. Does not invent numbers.
+
+use readcon_core::iterators::frames_from_text;
+use readcon_core::rcso::{encode_batch, Rcso};
+use readcon_core::rpc::client::RpcClient;
+use readcon_core::rpc::server;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixture_text(name: &str) -> String {
+    fs::read_to_string(repo_root().join("resources/test").join(name)).expect("fixture")
+}
+
+fn repeat_text(one: &str, n: usize) -> String {
+    let mut buf = String::with_capacity(one.len() * n);
+    for _ in 0..n {
+        buf.push_str(one);
+    }
+    buf
+}
+
+fn median_ms(mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    samples[samples.len() / 2]
+}
+
+fn time_ms<F: FnMut()>(repeat: usize, mut f: F) -> f64 {
+    let mut samples = Vec::with_capacity(repeat);
+    for _ in 0..repeat {
+        let t0 = Instant::now();
+        f();
+        samples.push(t0.elapsed().as_secs_f64() * 1.0e3);
+    }
+    median_ms(samples)
+}
+
+fn git_commit() -> String {
+    Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .current_dir(repo_root())
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn hostname() -> String {
+    Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn chrono_like_utc() -> String {
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%MZ"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn free_tcp_addr() -> String {
+    let l = TcpListener::bind("127.0.0.1:0").expect("ephemeral tcp");
+    let port = l.local_addr().expect("addr").port();
+    drop(l);
+    format!("127.0.0.1:{port}")
+}
+
+fn spawn_rpc(spec: String) {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt");
+        let local = tokio::task::LocalSet::new();
+        let _ = rt.block_on(local.run_until(server::start_server(&spec)));
+    });
+}
+
+fn wait_unix(path: &Path) {
+    let t0 = Instant::now();
+    while !path.exists() {
+        assert!(t0.elapsed() < Duration::from_secs(10), "unix bind {path:?}");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_tcp(addr: &str) {
+    let t0 = Instant::now();
+    loop {
+        if std::net::TcpStream::connect(addr).is_ok() {
+            return;
+        }
+        assert!(t0.elapsed() < Duration::from_secs(10), "tcp bind {addr}");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn main() {
+    let out_path = env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| repo_root().join("benches/results/leaf_io.json"));
+
+    let repeats = 5usize;
+    let n_frames = 100usize;
+    let one = fixture_text("cuh2.con");
+    let text = repeat_text(&one, n_frames);
+    let frames = frames_from_text(&text, Some(1)).expect("parse payload");
+    assert_eq!(frames.len(), n_frames);
+    let n_atoms = frames[0].atom_data.len();
+
+    let parse_ms = time_ms(repeats, || {
+        let got = frames_from_text(&text, Some(1)).expect("parse");
+        assert_eq!(got.len(), n_frames);
+        std::hint::black_box(got);
+    });
+
+    let blobs: Vec<Vec<u8>> = frames
+        .iter()
+        .map(|f| Rcso::encode_frame(f).expect("encode"))
+        .collect();
+    let batch = encode_batch(&blobs).expect("rcsb");
+
+    let pack_ms = time_ms(repeats, || {
+        let b: Vec<Vec<u8>> = frames
+            .iter()
+            .map(|f| Rcso::encode_frame(f).expect("encode"))
+            .collect();
+        let env = encode_batch(&b).expect("rcsb");
+        std::hint::black_box(env);
+    });
+
+    let decode_ms = time_ms(repeats, || {
+        let parts = readcon_core::rcso::decode_batch(&batch).expect("split");
+        let mut n = 0usize;
+        for p in &parts {
+            let s = Rcso::decode(p).expect("decode");
+            n += s.positions.len();
+        }
+        assert_eq!(n, n_frames * n_atoms);
+        std::hint::black_box(n);
+    });
+
+    let sock = std::env::temp_dir().join(format!("readcon-leaf-{}.sock", std::process::id()));
+    let _ = fs::remove_file(&sock);
+    let unix_spec = format!("unix:{}", sock.display());
+    spawn_rpc(unix_spec.clone());
+    wait_unix(&sock);
+    let unix_client = RpcClient::new(&unix_spec).expect("unix client");
+    let unix_ms = time_ms(repeats, || {
+        let got = unix_client.parse_bytes(one.as_bytes()).expect("unix parse");
+        assert_eq!(got[0].atom_data.len(), n_atoms);
+        std::hint::black_box(got);
+    });
+
+    let tcp_spec = free_tcp_addr();
+    spawn_rpc(tcp_spec.clone());
+    wait_tcp(&tcp_spec);
+    let tcp_client = RpcClient::new(&tcp_spec).expect("tcp client");
+    let tcp_ms = time_ms(repeats, || {
+        let got = tcp_client.parse_bytes(one.as_bytes()).expect("tcp parse");
+        assert_eq!(got[0].atom_data.len(), n_atoms);
+        std::hint::black_box(got);
+    });
+    let _ = fs::remove_file(&sock);
+
+    let ncpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    let ratio_parse_over_decode = if decode_ms > 0.0 {
+        parse_ms / decode_ms
+    } else {
+        0.0
+    };
+    let ratio_tcp_over_unix = if unix_ms > 0.0 { tcp_ms / unix_ms } else { 0.0 };
+
+    let mut json = String::new();
+    json.push_str("{\n");
+    json.push_str("  \"protocol\": \"cuh2.con x100: CON parse vs RCSO encode/decode; one-frame RpcClient parse_bytes Unix vs TCP loopback\",\n");
+    json.push_str(&format!("  \"host\": \"{}\",\n", hostname()));
+    json.push_str(&format!("  \"date_utc\": \"{}\",\n", chrono_like_utc()));
+    json.push_str(&format!("  \"commit\": \"{}\",\n", git_commit()));
+    json.push_str("  \"features\": \"rpc\",\n");
+    json.push_str(&format!("  \"ncpus\": {},\n", ncpus));
+    json.push_str(&format!("  \"n_frames\": {},\n", n_frames));
+    json.push_str(&format!("  \"n_atoms\": {},\n", n_atoms));
+    json.push_str(&format!("  \"repeats\": {},\n", repeats));
+    json.push_str("  \"fixture\": \"resources/test/cuh2.con\",\n");
+    json.push_str(&format!("  \"payload_bytes\": {},\n", text.len()));
+    json.push_str(&format!("  \"one_frame_bytes\": {},\n", one.len()));
+    json.push_str(&format!("  \"rcsb_bytes\": {},\n", batch.len()));
+    json.push_str(&format!("  \"parse_100_frames_ms\": {:.6},\n", parse_ms));
+    json.push_str(&format!("  \"rcso_pack_100_ms\": {:.6},\n", pack_ms));
+    json.push_str(&format!("  \"rcso_decode_100_ms\": {:.6},\n", decode_ms));
+    json.push_str(&format!("  \"parse_over_decode\": {:.4},\n", ratio_parse_over_decode));
+    json.push_str(&format!("  \"rpc_unix_one_frame_ms\": {:.6},\n", unix_ms));
+    json.push_str(&format!("  \"rpc_tcp_one_frame_ms\": {:.6},\n", tcp_ms));
+    json.push_str(&format!("  \"tcp_over_unix\": {:.4}\n", ratio_tcp_over_unix));
+    json.push_str("}\n");
+
+    if let Some(parent) = out_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let mut f = fs::File::create(&out_path).expect("create json");
+    f.write_all(json.as_bytes()).expect("write json");
+    println!("wrote {}", Path::new(&out_path).display());
+    print!("{json}");
+}

--- a/include/readcon-core.h
+++ b/include/readcon-core.h
@@ -669,6 +669,39 @@ struct CConFrameIterator *read_con_buffer_iterator(const uint8_t *data,
 struct RKRConFrame *con_frame_iterator_next(struct CConFrameIterator *iterator);
 
 /**
+ * Pack a frame as RCSO bytes for a caller-side MPI_Bcast.
+ * `buf == NULL` writes the required size to `*out_len`.
+ * Does not call MPI.
+ */
+enum RKRStatus rkr_pack_rcso(const struct RKRConFrame *frame_handle,
+                             uint8_t *buf,
+                             uintptr_t buflen,
+                             uintptr_t *out_len);
+
+/**
+ * Read natoms from an RCSO blob. Does not call MPI.
+ */
+enum RKRStatus rkr_unpack_rcso_natoms(const uint8_t *buf,
+                                      uintptr_t buflen,
+                                      uint32_t *out_natoms);
+
+/**
+ * Copy RCSO positions into row-major dest (`natoms * 3` doubles).
+ */
+enum RKRStatus rkr_unpack_rcso_positions(const uint8_t *buf,
+                                         uintptr_t buflen,
+                                         double *dest,
+                                         uint32_t dest_natoms);
+
+/**
+ * Copy RCSO forces. `RKR_STATUS_SECTION_ABSENT` if the blob has none.
+ */
+enum RKRStatus rkr_unpack_rcso_forces(const uint8_t *buf,
+                                      uintptr_t buflen,
+                                      double *dest,
+                                      uint32_t dest_natoms);
+
+/**
  * Skip one frame without parsing atoms. `RKR_STATUS_SUCCESS` on skip,
  * `RKR_STATUS_INDEX_OUT_OF_BOUNDS` at EOF, other codes on parse error.
  */

--- a/include/readcon-core.h
+++ b/include/readcon-core.h
@@ -91,6 +91,21 @@ namespace readcon {
 #define CON_SPEC_VERSION 3
 
 /**
+ * Breaking-change major for the public C ABI.
+ */
+#define RKR_ABI_VERSION_MAJOR 1
+
+/**
+ * Additive-change minor for the public C ABI.
+ */
+#define RKR_ABI_VERSION_MINOR 0
+
+/**
+ * Layout revision for opaque handles and exported records.
+ */
+#define RKR_ABI_LAYOUT_REVISION 1
+
+/**
  * CON/convel format spec version. Use `#if RKR_CON_SPEC_VERSION >= 2` in C/C++
  * to gate code that depends on atom_index semantics.
  *
@@ -409,6 +424,26 @@ typedef struct RKRArrayView {
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
+
+/**
+ * Returns the breaking-change major for the public C ABI.
+ */
+uint32_t rkr_abi_version_major(void);
+
+/**
+ * Returns the additive-change minor for the public C ABI.
+ */
+uint32_t rkr_abi_version_minor(void);
+
+/**
+ * Returns the opaque-handle and exported-record layout revision.
+ */
+uint32_t rkr_abi_layout_revision(void);
+
+/**
+ * Returns the stable human-readable ABI negotiation stamp.
+ */
+const char *rkr_abi_stamp(void);
 
 /**
  * Returns the spec version at runtime (for dynamically linked consumers).

--- a/paper/cpc/src/rg_main.org
+++ b/paper/cpc/src/rg_main.org
@@ -283,11 +283,11 @@ the same magic-byte detection. Both decompress to text and then
 parse. They are not a new format.
 
 A Cap'n Proto schema (=schema/ReadCon.capnp=) exists for an
-optional Rust RPC service. It is a parsed-frame transport. It is not
-an on-disk ``bcon'' authority. The campaign store
-=readcon-db= keeps cooked SoA numerics in LMDB (RCSO) as a
-derived cache. Text CON remains the file that independent tools must
-implement.
+optional Rust RPC service. It is a parsed-frame encoding over TCP or
+a Unix domain socket. It is not UCX, ADIOS, or an on-disk ``bcon''
+authority. The campaign store =readcon-db= keeps cooked SoA
+numerics in LMDB (RCSO) as a derived cache. Text CON remains the
+file that independent tools must implement.
 
 * Library architecture
 :PROPERTIES:

--- a/schema/ReadCon.capnp
+++ b/schema/ReadCon.capnp
@@ -70,18 +70,29 @@ struct ConFrameData {
 
 struct ParseRequest {
   fileContents @0 :Data;
+  compatibility @1 :CompatibilityStamp;
+}
+
+struct CompatibilityStamp {
+  abiMajor @0 :UInt32;
+  abiMinor @1 :UInt32;
+  abiLayoutRevision @2 :UInt32;
+  conSpecVersion @3 :UInt32;
 }
 
 struct ParseResult {
   frames @0 :List(ConFrameData);
+  compatibility @1 :CompatibilityStamp;
 }
 
 struct WriteRequest {
   frames @0 :List(ConFrameData);
+  compatibility @1 :CompatibilityStamp;
 }
 
 struct WriteResult {
   fileContents @0 :Data;
+  compatibility @1 :CompatibilityStamp;
 }
 
 interface ReadConService {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -9,6 +9,38 @@ use std::ptr;
 //=============================================================================
 // Version & Spec Constants (exported as #define by cbindgen)
 //=============================================================================
+/// Breaking-change major for the public C ABI.
+pub const RKR_ABI_VERSION_MAJOR: u32 = 1;
+/// Additive-change minor for the public C ABI.
+pub const RKR_ABI_VERSION_MINOR: u32 = 0;
+/// Layout revision for opaque handles and exported records.
+pub const RKR_ABI_LAYOUT_REVISION: u32 = 1;
+
+/// Returns the breaking-change major for the public C ABI.
+#[unsafe(no_mangle)]
+pub extern "C" fn rkr_abi_version_major() -> u32 {
+    RKR_ABI_VERSION_MAJOR
+}
+
+/// Returns the additive-change minor for the public C ABI.
+#[unsafe(no_mangle)]
+pub extern "C" fn rkr_abi_version_minor() -> u32 {
+    RKR_ABI_VERSION_MINOR
+}
+
+/// Returns the opaque-handle and exported-record layout revision.
+#[unsafe(no_mangle)]
+pub extern "C" fn rkr_abi_layout_revision() -> u32 {
+    RKR_ABI_LAYOUT_REVISION
+}
+
+/// Returns the stable human-readable ABI negotiation stamp.
+#[unsafe(no_mangle)]
+pub extern "C" fn rkr_abi_stamp() -> *const c_char {
+    const STAMP: &[u8] = b"readcon-core/abi-1.0/layout-1\0";
+    STAMP.as_ptr() as *const c_char
+}
+
 /// CON/convel format spec version. Use `#if RKR_CON_SPEC_VERSION >= 2` in C/C++
 /// to gate code that depends on atom_index semantics.
 ///

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -4396,6 +4396,136 @@ pub unsafe extern "C" fn rkr_dlpack_delete(tensor: *mut RKRDLManagedTensorVersio
         }
     }
 }
+
+/// Pack a frame as RCSO bytes for a caller-side `MPI_Bcast`.
+///
+/// `buf == NULL` writes the required size to `*out_len` and returns
+/// success. If `buf` is non-null and `buflen` is too small, returns
+/// `BUFFER_TOO_SMALL` and still writes the need to `*out_len`.
+/// This function does not call MPI.
+///
+/// # Safety
+/// `frame_handle` valid. `out_len` non-null. `buf` valid for `buflen` if non-null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rkr_pack_rcso(
+    frame_handle: *const RKRConFrame,
+    buf: *mut u8,
+    buflen: usize,
+    out_len: *mut usize,
+) -> RKRStatus {
+    if out_len.is_null() {
+        return RKRStatus::RKR_STATUS_NULL_POINTER;
+    }
+    let frame = match unsafe { (frame_handle as *const ConFrame).as_ref() } {
+        Some(f) => f,
+        None => return RKRStatus::RKR_STATUS_NULL_POINTER,
+    };
+    let bytes = match crate::rcso::Rcso::encode_frame(frame) {
+        Ok(b) => b,
+        Err(_) => return RKRStatus::RKR_STATUS_VALIDATION_ERROR,
+    };
+    unsafe { *out_len = bytes.len() };
+    if buf.is_null() {
+        return RKRStatus::RKR_STATUS_SUCCESS;
+    }
+    if buflen < bytes.len() {
+        return RKRStatus::RKR_STATUS_BUFFER_TOO_SMALL;
+    }
+    unsafe {
+        ptr::copy_nonoverlapping(bytes.as_ptr(), buf, bytes.len());
+    }
+    RKRStatus::RKR_STATUS_SUCCESS
+}
+
+/// Read `natoms` from an RCSO blob. No MPI.
+///
+/// # Safety
+/// `buf` valid for `buflen`. `out_natoms` non-null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rkr_unpack_rcso_natoms(
+    buf: *const u8,
+    buflen: usize,
+    out_natoms: *mut u32,
+) -> RKRStatus {
+    if buf.is_null() || out_natoms.is_null() {
+        return RKRStatus::RKR_STATUS_NULL_POINTER;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(buf, buflen) };
+    match crate::rcso::Rcso::decode(bytes) {
+        Ok(s) => {
+            unsafe { *out_natoms = s.natoms };
+            RKRStatus::RKR_STATUS_SUCCESS
+        }
+        Err(_) => RKRStatus::RKR_STATUS_VALIDATION_ERROR,
+    }
+}
+
+/// Copy RCSO positions into row-major `dest` (`natoms * 3` doubles).
+///
+/// # Safety
+/// `buf` valid for `buflen`. `dest` valid for `dest_natoms * 3` f64.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rkr_unpack_rcso_positions(
+    buf: *const u8,
+    buflen: usize,
+    dest: *mut f64,
+    dest_natoms: u32,
+) -> RKRStatus {
+    if buf.is_null() || dest.is_null() {
+        return RKRStatus::RKR_STATUS_NULL_POINTER;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(buf, buflen) };
+    let soa = match crate::rcso::Rcso::decode(bytes) {
+        Ok(s) => s,
+        Err(_) => return RKRStatus::RKR_STATUS_VALIDATION_ERROR,
+    };
+    if soa.natoms != dest_natoms {
+        return RKRStatus::RKR_STATUS_BUFFER_TOO_SMALL;
+    }
+    let out = unsafe { std::slice::from_raw_parts_mut(dest, dest_natoms as usize * 3) };
+    for (i, p) in soa.positions.iter().enumerate() {
+        out[i * 3] = p[0];
+        out[i * 3 + 1] = p[1];
+        out[i * 3 + 2] = p[2];
+    }
+    RKRStatus::RKR_STATUS_SUCCESS
+}
+
+/// Copy RCSO forces into row-major `dest`. `SECTION_ABSENT` if the blob
+/// has no force block.
+///
+/// # Safety
+/// `buf` valid for `buflen`. `dest` valid for `dest_natoms * 3` f64.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rkr_unpack_rcso_forces(
+    buf: *const u8,
+    buflen: usize,
+    dest: *mut f64,
+    dest_natoms: u32,
+) -> RKRStatus {
+    if buf.is_null() || dest.is_null() {
+        return RKRStatus::RKR_STATUS_NULL_POINTER;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(buf, buflen) };
+    let soa = match crate::rcso::Rcso::decode(bytes) {
+        Ok(s) => s,
+        Err(_) => return RKRStatus::RKR_STATUS_VALIDATION_ERROR,
+    };
+    let Some(forces) = soa.forces else {
+        return RKRStatus::RKR_STATUS_SECTION_ABSENT;
+    };
+    if soa.natoms != dest_natoms {
+        return RKRStatus::RKR_STATUS_BUFFER_TOO_SMALL;
+    }
+    let out = unsafe { std::slice::from_raw_parts_mut(dest, dest_natoms as usize * 3) };
+    for (i, f) in forces.iter().enumerate() {
+        out[i * 3] = f[0];
+        out[i * 3 + 1] = f[1];
+        out[i * 3 + 2] = f[2];
+    }
+    RKRStatus::RKR_STATUS_SUCCESS
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4508,6 +4638,38 @@ mod tests {
         let copied = unsafe { CStr::from_ptr(buffer.as_ptr()) };
         assert_eq!(copied.to_str().unwrap(), "Generated");
     }
+
+    #[test]
+    fn pack_rcso_size_query_then_dest() {
+        let path = std::ffi::CString::new("resources/test/tiny_cuh2_forces.con").unwrap();
+        let frame = unsafe { rkr_read_nth_frame(path.as_ptr(), 0) };
+        assert!(!frame.is_null());
+        let mut need = 0usize;
+        let st = unsafe { rkr_pack_rcso(frame, std::ptr::null_mut(), 0, &mut need) };
+        assert_eq!(st, RKRStatus::RKR_STATUS_SUCCESS);
+        assert!(need >= 24);
+        let mut buf = vec![0u8; need];
+        let mut wrote = 0usize;
+        let st = unsafe { rkr_pack_rcso(frame, buf.as_mut_ptr(), buf.len(), &mut wrote) };
+        assert_eq!(st, RKRStatus::RKR_STATUS_SUCCESS);
+        assert_eq!(wrote, need);
+        assert_eq!(&buf[0..4], b"RCSO");
+        let mut natoms = 0u32;
+        let st = unsafe { rkr_unpack_rcso_natoms(buf.as_ptr(), buf.len(), &mut natoms) };
+        assert_eq!(st, RKRStatus::RKR_STATUS_SUCCESS);
+        assert_eq!(natoms, unsafe { rkr_frame_atom_count(frame) } as u32);
+        let mut xyz = vec![0.0f64; natoms as usize * 3];
+        let st = unsafe {
+            rkr_unpack_rcso_positions(buf.as_ptr(), buf.len(), xyz.as_mut_ptr(), natoms)
+        };
+        assert_eq!(st, RKRStatus::RKR_STATUS_SUCCESS);
+        let mut frc = vec![0.0f64; natoms as usize * 3];
+        let st =
+            unsafe { rkr_unpack_rcso_forces(buf.as_ptr(), buf.len(), frc.as_mut_ptr(), natoms) };
+        assert_eq!(st, RKRStatus::RKR_STATUS_SUCCESS);
+        unsafe { free_rkr_frame(frame) };
+    }
+
     fn test_builder_handle() -> *mut RKRConFrameBuilder {
         let cell = [10.0, 11.0, 12.0];
         let angles = [90.0, 91.0, 92.0];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod ffi;
 pub mod helpers;
 /// Campaign screening scalars / CON ingest contracts for corpus stores (`readcon-db`).
 pub mod index_proj;
+/// RCSO/RCSB cooked numerics for a caller-side broadcast. No MPI in this crate.
+pub mod rcso;
 pub mod iterators;
 pub mod parser;
 #[cfg(feature = "grammar")]

--- a/src/rcso.rs
+++ b/src/rcso.rs
@@ -1,0 +1,280 @@
+//! RCSO cooked SoA bytes for a caller-side `MPI_Bcast`.
+//!
+//! Layout matches readcon-db `cooked_soa` v1 (little-endian):
+//! magic `RCSO`, version, natoms, flags, dtype, pad, reserved,
+//! then positions, optional forces, optional velocities.
+//!
+//! This crate never calls `MPI_Init` or names WORLD. Rank 0 encodes;
+//! the caller broadcasts; workers decode.
+
+use crate::error::ParseError;
+use crate::types::ConFrame;
+
+/// Four-byte magic. Identical to readcon-db.
+pub const RCSO_MAGIC: &[u8; 4] = b"RCSO";
+/// Layout version 1.
+pub const RCSO_VERSION: u32 = 1;
+/// Positions/forces/velocities stored as f64.
+pub const RCSO_DTYPE_F64: u8 = 0;
+/// Bit 0: forces block present.
+pub const RCSO_FLAG_FORCES: u32 = 1 << 0;
+/// Bit 1: velocities block present.
+pub const RCSO_FLAG_VELOCITIES: u32 = 1 << 1;
+
+const HEADER_LEN: usize = 24;
+
+/// Length-prefixed RCSO blobs for one collective (ADIOS BP5 grain: many frames).
+pub const RCSB_MAGIC: &[u8; 4] = b"RCSB";
+/// Batch envelope version 1.
+pub const RCSB_VERSION: u32 = 1;
+
+/// Decoded cooked numerics.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Rcso {
+    pub natoms: u32,
+    pub positions: Vec<[f64; 3]>,
+    pub forces: Option<Vec<[f64; 3]>>,
+    pub velocities: Option<Vec<[f64; 3]>>,
+}
+
+fn err(msg: impl Into<String>) -> ParseError {
+    ParseError::ValidationError(msg.into())
+}
+
+impl Rcso {
+    /// Pack one parsed frame. CON text stays the authority.
+    pub fn encode_frame(frame: &ConFrame) -> Result<Vec<u8>, ParseError> {
+        let n = frame.atom_data.len();
+        if n > u32::MAX as usize {
+            return Err(err("too many atoms for RCSO"));
+        }
+        let natoms = n as u32;
+        let has_f = frame.atom_data.iter().any(|a| a.force.is_some());
+        let has_v = frame.atom_data.iter().any(|a| a.velocity.is_some());
+        let mut flags = 0u32;
+        if has_f {
+            flags |= RCSO_FLAG_FORCES;
+        }
+        if has_v {
+            flags |= RCSO_FLAG_VELOCITIES;
+        }
+
+        let mut out =
+            Vec::with_capacity(HEADER_LEN + n * 3 * 8 * (1 + has_f as usize + has_v as usize));
+        out.extend_from_slice(RCSO_MAGIC);
+        out.extend_from_slice(&RCSO_VERSION.to_le_bytes());
+        out.extend_from_slice(&natoms.to_le_bytes());
+        out.extend_from_slice(&flags.to_le_bytes());
+        out.push(RCSO_DTYPE_F64);
+        out.extend_from_slice(&[0u8; 3]);
+        out.extend_from_slice(&0u32.to_le_bytes());
+
+        for a in &frame.atom_data {
+            for c in [a.x, a.y, a.z] {
+                out.extend_from_slice(&c.to_le_bytes());
+            }
+        }
+        if has_f {
+            for a in &frame.atom_data {
+                let f = a.force.unwrap_or([0.0; 3]);
+                for c in f {
+                    out.extend_from_slice(&c.to_le_bytes());
+                }
+            }
+        }
+        if has_v {
+            for a in &frame.atom_data {
+                let v = a.velocity.unwrap_or([0.0; 3]);
+                for c in v {
+                    out.extend_from_slice(&c.to_le_bytes());
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Decode a v1 RCSO blob.
+    pub fn decode(bytes: &[u8]) -> Result<Self, ParseError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(err("RCSO truncated header"));
+        }
+        if &bytes[0..4] != RCSO_MAGIC {
+            return Err(err("RCSO bad magic"));
+        }
+        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        if version != RCSO_VERSION {
+            return Err(err(format!("RCSO unsupported version {version}")));
+        }
+        let natoms = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        let flags = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+        let dtype = bytes[16];
+        if dtype != RCSO_DTYPE_F64 {
+            return Err(err(format!("RCSO unsupported dtype {dtype}")));
+        }
+        let n = natoms as usize;
+        let block = n.checked_mul(3).ok_or_else(|| err("RCSO overflow"))?;
+        let block_bytes = block.checked_mul(8).ok_or_else(|| err("RCSO overflow"))?;
+        let mut need = HEADER_LEN + block_bytes;
+        let has_f = flags & RCSO_FLAG_FORCES != 0;
+        let has_v = flags & RCSO_FLAG_VELOCITIES != 0;
+        if has_f {
+            need = need
+                .checked_add(block_bytes)
+                .ok_or_else(|| err("RCSO overflow"))?;
+        }
+        if has_v {
+            need = need
+                .checked_add(block_bytes)
+                .ok_or_else(|| err("RCSO overflow"))?;
+        }
+        if bytes.len() < need {
+            return Err(err("RCSO truncated body"));
+        }
+
+        let mut off = HEADER_LEN;
+        let positions = read_vec3_block(&bytes[off..off + block_bytes], n)?;
+        off += block_bytes;
+        let forces = if has_f {
+            let f = read_vec3_block(&bytes[off..off + block_bytes], n)?;
+            off += block_bytes;
+            Some(f)
+        } else {
+            None
+        };
+        let velocities = if has_v {
+            Some(read_vec3_block(&bytes[off..off + block_bytes], n)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            natoms,
+            positions,
+            forces,
+            velocities,
+        })
+    }
+}
+
+fn read_vec3_block(bytes: &[u8], n: usize) -> Result<Vec<[f64; 3]>, ParseError> {
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let base = i * 24;
+        let x = f64::from_le_bytes(bytes[base..base + 8].try_into().unwrap());
+        let y = f64::from_le_bytes(bytes[base + 8..base + 16].try_into().unwrap());
+        let z = f64::from_le_bytes(bytes[base + 16..base + 24].try_into().unwrap());
+        out.push([x, y, z]);
+    }
+    Ok(out)
+}
+
+/// Pack many RCSO blobs into one RCSB envelope (one Bcast).
+pub fn encode_batch(blobs: &[Vec<u8>]) -> Result<Vec<u8>, ParseError> {
+    if blobs.len() > u32::MAX as usize {
+        return Err(err("too many frames in RCSB batch"));
+    }
+    let mut out = Vec::new();
+    out.extend_from_slice(RCSB_MAGIC);
+    out.extend_from_slice(&RCSB_VERSION.to_le_bytes());
+    out.extend_from_slice(&(blobs.len() as u32).to_le_bytes());
+    for b in blobs {
+        if b.len() > u32::MAX as usize {
+            return Err(err("RCSO blob exceeds u32 length"));
+        }
+        out.extend_from_slice(&(b.len() as u32).to_le_bytes());
+        out.extend_from_slice(b);
+    }
+    Ok(out)
+}
+
+/// Split an RCSB envelope into RCSO blobs.
+pub fn decode_batch(bytes: &[u8]) -> Result<Vec<Vec<u8>>, ParseError> {
+    if bytes.len() < 12 {
+        return Err(err("RCSB truncated header"));
+    }
+    if &bytes[0..4] != RCSB_MAGIC {
+        return Err(err("RCSB bad magic"));
+    }
+    let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+    if version != RCSB_VERSION {
+        return Err(err(format!("RCSB unsupported version {version}")));
+    }
+    let n = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+    let mut off = 12usize;
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        if off + 4 > bytes.len() {
+            return Err(err("RCSB truncated length"));
+        }
+        let ln = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()) as usize;
+        off += 4;
+        if off + ln > bytes.len() {
+            return Err(err("RCSB truncated blob"));
+        }
+        out.push(bytes[off..off + ln].to_vec());
+        off += ln;
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::iterators::ConFrameIterator;
+
+    fn first_frame(text: &str) -> ConFrame {
+        ConFrameIterator::new(text)
+            .next()
+            .expect("frame")
+            .expect("parse")
+    }
+
+    #[test]
+    fn v2_minimal_roundtrip_positions() {
+        let text = include_str!("../resources/conformance/valid/v2_minimal.con");
+        let frame = first_frame(text);
+        let blob = Rcso::encode_frame(&frame).unwrap();
+        assert_eq!(&blob[0..4], b"RCSO");
+        assert_eq!(u32::from_le_bytes(blob[4..8].try_into().unwrap()), 1);
+        let got = Rcso::decode(&blob).unwrap();
+        assert_eq!(got.natoms as usize, frame.atom_data.len());
+        assert!(got.forces.is_none());
+        assert!(got.velocities.is_none());
+        for (a, p) in frame.atom_data.iter().zip(&got.positions) {
+            assert_eq!([a.x, a.y, a.z], *p);
+        }
+    }
+
+    #[test]
+    fn forces_fixture_keeps_force_block() {
+        let text = include_str!("../resources/test/tiny_cuh2_forces.con");
+        let frame = first_frame(text);
+        assert!(frame.atom_data.iter().any(|a| a.force.is_some()));
+        let blob = Rcso::encode_frame(&frame).unwrap();
+        let flags = u32::from_le_bytes(blob[12..16].try_into().unwrap());
+        assert_ne!(flags & RCSO_FLAG_FORCES, 0);
+        let got = Rcso::decode(&blob).unwrap();
+        let forces = got.forces.expect("forces");
+        for (a, f) in frame.atom_data.iter().zip(&forces) {
+            assert_eq!(a.force.unwrap_or([0.0; 3]), *f);
+        }
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        assert!(Rcso::decode(b"NOPE").is_err());
+    }
+
+    #[test]
+    fn rcsb_batch_holds_two_blobs() {
+        let text = include_str!("../resources/conformance/valid/v2_minimal.con");
+        let frame = first_frame(text);
+        let a = Rcso::encode_frame(&frame).unwrap();
+        let b = a.clone();
+        let batch = encode_batch(&[a.clone(), b.clone()]).unwrap();
+        assert_eq!(&batch[0..4], b"RCSB");
+        let parts = decode_batch(&batch).unwrap();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0], a);
+        assert_eq!(parts[1], b);
+    }
+}

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -158,7 +158,7 @@ mod unix_tests {
         let client = RpcClient::new(&spec).expect("client");
         let frames = client.parse_bytes(MINIMAL.as_bytes()).expect("parse");
         assert_eq!(frames.len(), 1);
-        assert_eq!(frames[0].atom_count(), 1);
+        assert_eq!(frames[0].atom_data.len(), 1);
         let _ = std::fs::remove_file(&sock);
     }
 }

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -3,6 +3,7 @@ use futures::AsyncReadExt;
 
 use super::convert::{fill_frame_builder, frame_from_reader};
 use super::read_con_capnp::read_con_service;
+use super::{set_compatibility_stamp, validate_compatibility_stamp};
 use crate::types::ConFrame;
 
 /// A synchronous RPC client that wraps the Cap'n Proto async transport.
@@ -55,9 +56,14 @@ impl RpcClient {
                     tokio::task::spawn_local(rpc_system);
 
                     let mut request = service.parse_frames_request();
-                    request.get().init_req().set_file_contents(data);
+                    {
+                        let mut parse_request = request.get().init_req();
+                        set_compatibility_stamp(parse_request.reborrow().init_compatibility());
+                        parse_request.set_file_contents(data);
+                    }
                     let response = request.send().promise.await?;
                     let result = response.get()?.get_result()?;
+                    validate_compatibility_stamp(result.get_compatibility()?)?;
                     let frame_data_list = result.get_frames()?;
 
                     let mut frames = Vec::with_capacity(frame_data_list.len() as usize);
@@ -94,6 +100,7 @@ impl RpcClient {
                     let mut request = service.write_frames_request();
                     {
                         let mut wr = request.get().init_req();
+                        set_compatibility_stamp(wr.reborrow().init_compatibility());
                         let mut list = wr.reborrow().init_frames(frames.len() as u32);
                         for (i, frame) in frames.iter().enumerate() {
                             fill_frame_builder(list.reborrow().get(i as u32), frame)
@@ -102,6 +109,7 @@ impl RpcClient {
                     }
                     let response = request.send().promise.await?;
                     let result = response.get()?.get_result()?;
+                    validate_compatibility_stamp(result.get_compatibility()?)?;
                     let bytes = result.get_file_contents()?;
                     Ok(bytes.to_vec())
                 })

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -2,24 +2,59 @@ use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use futures::AsyncReadExt;
 
 use super::convert::{fill_frame_builder, frame_from_reader};
+use super::endpoint::Endpoint;
 use super::read_con_capnp::read_con_service;
 use super::{set_compatibility_stamp, validate_compatibility_stamp};
 use crate::types::ConFrame;
 
 /// A synchronous RPC client that wraps the Cap'n Proto async transport.
 pub struct RpcClient {
-    addr: String,
+    endpoint: Endpoint,
     runtime: tokio::runtime::Runtime,
 }
 
+async fn connect_service(
+    endpoint: &Endpoint,
+) -> Result<read_con_service::Client, Box<dyn std::error::Error>> {
+    match endpoint {
+        Endpoint::Tcp(addr) => {
+            let stream = tokio::net::TcpStream::connect(addr).await?;
+            stream.set_nodelay(true)?;
+            Ok(bootstrap_client(stream))
+        }
+        #[cfg(unix)]
+        Endpoint::Unix(path) => {
+            let stream = tokio::net::UnixStream::connect(path).await?;
+            Ok(bootstrap_client(stream))
+        }
+    }
+}
+
+fn bootstrap_client<S>(stream: S) -> read_con_service::Client
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + 'static,
+{
+    let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+    let network = twoparty::VatNetwork::new(
+        reader,
+        writer,
+        rpc_twoparty_capnp::Side::Client,
+        Default::default(),
+    );
+    let mut rpc_system = RpcSystem::new(Box::new(network), None);
+    let service: read_con_service::Client = rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
+    tokio::task::spawn_local(rpc_system);
+    service
+}
+
 impl RpcClient {
-    /// Creates a new RPC client targeting the given address.
+    /// Creates a new RPC client targeting TCP `host:port` or Unix `unix:/path`.
     pub fn new(addr: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
         Ok(Self {
-            addr: addr.to_string(),
+            endpoint: Endpoint::parse(addr)?,
             runtime,
         })
     }
@@ -39,21 +74,7 @@ impl RpcClient {
             let local = tokio::task::LocalSet::new();
             local
                 .run_until(async {
-                    let stream = tokio::net::TcpStream::connect(&self.addr).await?;
-                    stream.set_nodelay(true)?;
-                    let (reader, writer) =
-                        tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
-                    let network = twoparty::VatNetwork::new(
-                        reader,
-                        writer,
-                        rpc_twoparty_capnp::Side::Client,
-                        Default::default(),
-                    );
-                    let mut rpc_system = RpcSystem::new(Box::new(network), None);
-                    let service: read_con_service::Client =
-                        rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
-
-                    tokio::task::spawn_local(rpc_system);
+                    let service = connect_service(&self.endpoint).await?;
 
                     let mut request = service.parse_frames_request();
                     {
@@ -82,20 +103,7 @@ impl RpcClient {
             let local = tokio::task::LocalSet::new();
             local
                 .run_until(async {
-                    let stream = tokio::net::TcpStream::connect(&self.addr).await?;
-                    stream.set_nodelay(true)?;
-                    let (reader, writer) =
-                        tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
-                    let network = twoparty::VatNetwork::new(
-                        reader,
-                        writer,
-                        rpc_twoparty_capnp::Side::Client,
-                        Default::default(),
-                    );
-                    let mut rpc_system = RpcSystem::new(Box::new(network), None);
-                    let service: read_con_service::Client =
-                        rpc_system.bootstrap(rpc_twoparty_capnp::Side::Server);
-                    tokio::task::spawn_local(rpc_system);
+                    let service = connect_service(&self.endpoint).await?;
 
                     let mut request = service.write_frames_request();
                     {
@@ -115,5 +123,42 @@ impl RpcClient {
                 })
                 .await
         })
+    }
+}
+
+#[cfg(all(test, unix))]
+mod unix_tests {
+    use super::*;
+    use std::time::Duration;
+
+    const MINIMAL: &str = include_str!("../../resources/conformance/valid/v2_minimal.con");
+
+    #[test]
+    fn unix_socket_parse_roundtrip() {
+        let sock = std::env::temp_dir().join(format!("readcon-rpc-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&sock);
+        let spec = format!("unix:{}", sock.display());
+        let spec_server = spec.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            let local = tokio::task::LocalSet::new();
+            let _ = rt.block_on(local.run_until(crate::rpc::server::start_server(&spec_server)));
+        });
+        let started = std::time::Instant::now();
+        while !sock.exists() {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "unix server did not bind {sock:?}"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let client = RpcClient::new(&spec).expect("client");
+        let frames = client.parse_bytes(MINIMAL.as_bytes()).expect("parse");
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].atom_count(), 1);
+        let _ = std::fs::remove_file(&sock);
     }
 }

--- a/src/rpc/endpoint.rs
+++ b/src/rpc/endpoint.rs
@@ -1,0 +1,99 @@
+//! RPC listen/connect targets. Cap'n is the encoding; this is the byte pipe.
+//!
+//! - `host:port` and `[ipv6]:port` are TCP.
+//! - `unix:/abs/path`, `unix://abs/path`, or a path beginning with `/` is
+//!   a Unix domain socket (same-node HPC default).
+//!
+//! UCX/libfabric/ADIOS are not transports in this crate. They are optional
+//! later adapters if a campaign consumer exists.
+
+use std::path::PathBuf;
+
+/// Where the Cap'n two-party vat binds or connects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Endpoint {
+    Tcp(String),
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+impl Endpoint {
+    /// Parse a listen/connect spec.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let s = spec.trim();
+        if s.is_empty() {
+            return Err("empty RPC endpoint".into());
+        }
+        if let Some(rest) = s.strip_prefix("unix:") {
+            let path = rest.strip_prefix("//").unwrap_or(rest);
+            return unix_path(path);
+        }
+        if s.starts_with('/') {
+            return unix_path(s);
+        }
+        Ok(Endpoint::Tcp(s.to_string()))
+    }
+}
+
+#[cfg(unix)]
+fn unix_path(path: &str) -> Result<Endpoint, String> {
+    if path.is_empty() {
+        return Err("unix endpoint missing path".into());
+    }
+    Ok(Endpoint::Unix(PathBuf::from(path)))
+}
+
+#[cfg(not(unix))]
+fn unix_path(_path: &str) -> Result<Endpoint, String> {
+    Err("unix RPC endpoints require a Unix host".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tcp_host_port() {
+        assert_eq!(
+            Endpoint::parse("127.0.0.1:9876").unwrap(),
+            Endpoint::Tcp("127.0.0.1:9876".into())
+        );
+    }
+
+    #[test]
+    fn parses_tcp_ipv6() {
+        assert_eq!(
+            Endpoint::parse("[::1]:9876").unwrap(),
+            Endpoint::Tcp("[::1]:9876".into())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parses_unix_prefix_and_absolute_path() {
+        assert_eq!(
+            Endpoint::parse("unix:/tmp/readcon.sock").unwrap(),
+            Endpoint::Unix(PathBuf::from("/tmp/readcon.sock"))
+        );
+        assert_eq!(
+            Endpoint::parse("unix:///var/run/readcon.sock").unwrap(),
+            Endpoint::Unix(PathBuf::from("/var/run/readcon.sock"))
+        );
+        assert_eq!(
+            Endpoint::parse("/tmp/readcon.sock").unwrap(),
+            Endpoint::Unix(PathBuf::from("/tmp/readcon.sock"))
+        );
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(Endpoint::parse("").is_err());
+        assert!(Endpoint::parse("   ").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_unix_without_path() {
+        assert!(Endpoint::parse("unix:").is_err());
+    }
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -6,3 +6,36 @@ pub mod read_con_capnp {
 pub mod client;
 pub mod convert;
 pub mod server;
+
+use read_con_capnp::compatibility_stamp;
+
+/// Fill a wire compatibility record with this library's negotiated contract.
+pub fn set_compatibility_stamp(mut stamp: compatibility_stamp::Builder<'_>) {
+    stamp.set_abi_major(crate::ffi::RKR_ABI_VERSION_MAJOR);
+    stamp.set_abi_minor(crate::ffi::RKR_ABI_VERSION_MINOR);
+    stamp.set_abi_layout_revision(crate::ffi::RKR_ABI_LAYOUT_REVISION);
+    stamp.set_con_spec_version(crate::CON_SPEC_VERSION);
+}
+
+/// Reject a wire compatibility record that this library cannot safely consume.
+pub fn validate_compatibility_stamp(stamp: compatibility_stamp::Reader<'_>) -> Result<(), String> {
+    if stamp.get_abi_major() != crate::ffi::RKR_ABI_VERSION_MAJOR {
+        return Err(format!(
+            "incompatible readcon-core ABI major: {}",
+            stamp.get_abi_major()
+        ));
+    }
+    if stamp.get_abi_layout_revision() != crate::ffi::RKR_ABI_LAYOUT_REVISION {
+        return Err(format!(
+            "incompatible readcon-core ABI layout: {}",
+            stamp.get_abi_layout_revision()
+        ));
+    }
+    if stamp.get_con_spec_version() > crate::CON_SPEC_VERSION {
+        return Err(format!(
+            "unsupported CON spec version: {}",
+            stamp.get_con_spec_version()
+        ));
+    }
+    Ok(())
+}

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -25,6 +25,12 @@ pub fn validate_compatibility_stamp(stamp: compatibility_stamp::Reader<'_>) -> R
             stamp.get_abi_major()
         ));
     }
+    if stamp.get_abi_minor() > crate::ffi::RKR_ABI_VERSION_MINOR {
+        return Err(format!(
+            "unsupported readcon-core ABI minor: {}",
+            stamp.get_abi_minor()
+        ));
+    }
     if stamp.get_abi_layout_revision() != crate::ffi::RKR_ABI_LAYOUT_REVISION {
         return Err(format!(
             "incompatible readcon-core ABI layout: {}",

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -5,7 +5,10 @@ pub mod read_con_capnp {
 
 pub mod client;
 pub mod convert;
+pub mod endpoint;
 pub mod server;
+
+pub use endpoint::Endpoint;
 
 use read_con_capnp::compatibility_stamp;
 

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -39,3 +39,42 @@ pub fn validate_compatibility_stamp(stamp: compatibility_stamp::Reader<'_>) -> R
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_a_breaking_abi_major() {
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut stamp = message.init_root::<compatibility_stamp::Builder>();
+            stamp.set_abi_major(2);
+            stamp.set_abi_minor(crate::ffi::RKR_ABI_VERSION_MINOR);
+            stamp.set_abi_layout_revision(crate::ffi::RKR_ABI_LAYOUT_REVISION);
+            stamp.set_con_spec_version(crate::CON_SPEC_VERSION);
+        }
+        let stamp = message
+            .get_root_as_reader::<compatibility_stamp::Reader>()
+            .expect("compatibility stamp root");
+        let error = validate_compatibility_stamp(stamp).expect_err("major mismatch must fail");
+        assert!(error.contains("ABI major"));
+    }
+
+    #[test]
+    fn rejects_a_newer_abi_minor() {
+        let mut message = capnp::message::Builder::new_default();
+        {
+            let mut stamp = message.init_root::<compatibility_stamp::Builder>();
+            stamp.set_abi_major(crate::ffi::RKR_ABI_VERSION_MAJOR);
+            stamp.set_abi_minor(crate::ffi::RKR_ABI_VERSION_MINOR + 1);
+            stamp.set_abi_layout_revision(crate::ffi::RKR_ABI_LAYOUT_REVISION);
+            stamp.set_con_spec_version(crate::CON_SPEC_VERSION);
+        }
+        let stamp = message
+            .get_root_as_reader::<compatibility_stamp::Reader>()
+            .expect("compatibility stamp root");
+        let error = validate_compatibility_stamp(stamp).expect_err("newer minor must fail");
+        assert!(error.contains("ABI minor"));
+    }
+}

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -85,24 +85,45 @@ impl read_con_service::Server for ReadConServiceImpl {
     }
 }
 
-/// Starts an RPC server on the given address.
-///
-/// This function blocks until the server is shut down.
-pub async fn start_server(addr: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    let service: read_con_service::Client = capnp_rpc::new_client(ReadConServiceImpl);
+fn spawn_server_vat<S>(stream: S, service: read_con_service::Client)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + 'static,
+{
+    let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+    let network = twoparty::VatNetwork::new(
+        reader,
+        writer,
+        rpc_twoparty_capnp::Side::Server,
+        Default::default(),
+    );
+    let rpc_system = RpcSystem::new(Box::new(network), Some(service.client));
+    tokio::task::spawn_local(rpc_system);
+}
 
-    loop {
-        let (stream, _) = listener.accept().await?;
-        stream.set_nodelay(true)?;
-        let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
-        let network = twoparty::VatNetwork::new(
-            reader,
-            writer,
-            rpc_twoparty_capnp::Side::Server,
-            Default::default(),
-        );
-        let rpc_system = RpcSystem::new(Box::new(network), Some(service.clone().client));
-        tokio::task::spawn_local(rpc_system);
+/// Starts an RPC server on a TCP `host:port` or Unix `unix:/path` endpoint.
+///
+/// Blocks until the process is stopped. A pre-existing Unix socket file is
+/// removed before bind.
+pub async fn start_server(addr: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let ep = super::endpoint::Endpoint::parse(addr)?;
+    let service: read_con_service::Client = capnp_rpc::new_client(ReadConServiceImpl);
+    match ep {
+        super::endpoint::Endpoint::Tcp(bind) => {
+            let listener = tokio::net::TcpListener::bind(&bind).await?;
+            loop {
+                let (stream, _) = listener.accept().await?;
+                stream.set_nodelay(true)?;
+                spawn_server_vat(stream, service.clone());
+            }
+        }
+        #[cfg(unix)]
+        super::endpoint::Endpoint::Unix(path) => {
+            let _ = std::fs::remove_file(&path);
+            let listener = tokio::net::UnixListener::bind(&path)?;
+            loop {
+                let (stream, _) = listener.accept().await?;
+                spawn_server_vat(stream, service.clone());
+            }
+        }
     }
 }

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -7,6 +7,7 @@ use crate::writer::ConFrameWriter;
 
 use super::convert::{fill_frame_builder, frame_from_reader};
 use super::read_con_capnp::read_con_service;
+use super::{set_compatibility_stamp, validate_compatibility_stamp};
 
 struct ReadConServiceImpl;
 
@@ -17,7 +18,11 @@ impl read_con_service::Server for ReadConServiceImpl {
         mut results: read_con_service::ParseFramesResults,
     ) -> Promise<(), capnp::Error> {
         let req = pry!(params.get());
-        let file_bytes = pry!(pry!(req.get_req()).get_file_contents());
+        let parse_request = pry!(req.get_req());
+        if let Err(e) = validate_compatibility_stamp(pry!(parse_request.get_compatibility())) {
+            return Promise::err(capnp::Error::failed(e));
+        }
+        let file_bytes = pry!(parse_request.get_file_contents());
         let file_str = match std::str::from_utf8(file_bytes) {
             Ok(s) => s,
             Err(e) => return Promise::err(capnp::Error::failed(e.to_string())),
@@ -30,6 +35,7 @@ impl read_con_service::Server for ReadConServiceImpl {
         };
 
         let mut result_builder = results.get().init_result();
+        set_compatibility_stamp(result_builder.reborrow().init_compatibility());
         let mut frames_builder = result_builder.reborrow().init_frames(frames.len() as u32);
 
         for (i, frame) in frames.iter().enumerate() {
@@ -48,7 +54,11 @@ impl read_con_service::Server for ReadConServiceImpl {
         mut results: read_con_service::WriteFramesResults,
     ) -> Promise<(), capnp::Error> {
         let req = pry!(params.get());
-        let frame_data_list = pry!(pry!(req.get_req()).get_frames());
+        let write_request = pry!(req.get_req());
+        if let Err(e) = validate_compatibility_stamp(pry!(write_request.get_compatibility())) {
+            return Promise::err(capnp::Error::failed(e));
+        }
+        let frame_data_list = pry!(write_request.get_frames());
 
         let mut frames = Vec::with_capacity(frame_data_list.len() as usize);
         for i in 0..frame_data_list.len() {
@@ -67,7 +77,9 @@ impl read_con_service::Server for ReadConServiceImpl {
             }
         }
 
-        results.get().init_result().set_file_contents(&buffer);
+        let mut result = results.get().init_result();
+        result.set_file_contents(&buffer);
+        set_compatibility_stamp(result.reborrow().init_compatibility());
 
         Promise::ok(())
     }


### PR DESCRIPTION
RPC negotiation now rejects a newer ABI minor the same way it already rejects a newer major. The byte pipe is TCP (`host:port`) or a Unix domain socket (`unix:/path`). Same-node jobs should use the socket.

`Rcso::encode_frame` / `decode` emit the v1 `RCSO` cooked SoA blob (positions, optional forces/velocities). `RCSB` batches two or more blobs for one caller-side broadcast. The C ABI is `rkr_pack_rcso` (size-query then dest), `rkr_unpack_rcso_natoms`, `rkr_unpack_rcso_positions`, `rkr_unpack_rcso_forces`. This crate does not call MPI.

Cap'n is the parsed-frame encoding. It is not an on-disk format and it is not UCX/ADIOS.

## What

- `validate_compatibility_stamp` rejects `abi_minor > local`
- `Endpoint` + server/client dispatch for TCP and Unix
- `src/rcso.rs` + C pack/unpack in `src/ffi.rs` / `include/readcon-core.h`

## Test plan

- [x] `cargo test --features rpc --lib -- endpoint unix_socket rejects_a_`: 8 passed
- [x] `cargo test --lib -- pack_rcso rcso::`: 5 passed