### PR TITLE
test(rpc): keep the rpc feature free of UCX

### DIFF
--- a/scripts/check_rpc_no_ucx.sh
+++ b/scripts/check_rpc_no_ucx.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# rpc feature must stay free of UCX/libfabric. Those fabrics are optional
+# later adapters when a campaign consumer exists (not a hard dep).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOML="$ROOT/Cargo.toml"
+
+# The rpc feature list and [dependencies] must not name a UCX crate.
+if awk '
+  /^\[features\]/ {f=1; next}
+  f && /^\[/ {f=0}
+  f && /^rpc[[:space:]]*=/ {print}
+' "$TOML" | grep -qiE 'ucx|libfabric|ucx-sys'; then
+  echo "ERROR: Cargo.toml rpc feature lists a UCX crate" >&2
+  exit 1
+fi
+
+if awk '
+  /^\[dependencies\]/ {d=1; next}
+  d && /^\[/ {d=0}
+  d {print}
+' "$TOML" | grep -qiE '^ucx|^ucx-sys|^libfabric'; then
+  echo "ERROR: Cargo.toml [dependencies] names a UCX crate" >&2
+  exit 1
+fi
+
+# Endpoint dispatch is TCP and Unix only.
+if grep -nE 'Endpoint::Ucx|unix::ucx|libucx' "$ROOT/src/rpc"/*.rs "$ROOT/src/rpc"/**/*.rs 2>/dev/null \
+  | grep -v 'UCX/libfabric/ADIOS are not transports'; then
+  echo "ERROR: rpc sources name a UCX endpoint" >&2
+  exit 1
+fi
+
+echo "OK: rpc feature has no UCX dependency"

--- a/tests/ci_gates.rs
+++ b/tests/ci_gates.rs
@@ -37,3 +37,8 @@ fn release_workflow_pins_actions_and_verifies_installers() {
 fn language_package_versions_match_cargo() {
     run_gate("scripts/check_version_lockstep.sh");
 }
+
+#[test]
+fn rpc_feature_has_no_ucx_dependency() {
+    run_gate("scripts/check_rpc_no_ucx.sh");
+}


### PR DESCRIPTION
The rpc byte pipe is TCP or a Unix domain socket. UCX is not a CON store and is not a hard dependency.

This gate fails if the `rpc` feature list, `[dependencies]`, or `src/rpc` grow a UCX crate or `Endpoint::Ucx`. `cargo test --features rpc` stays free of libucx.

## What

- `scripts/check_rpc_no_ucx.sh` + `ci_gates` test

## Test plan

- [x] `bash scripts/check_rpc_no_ucx.sh`