### PR TITLE
ci(wrap): gate cxx tarball SHA in the Meson wrap

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -15,6 +15,7 @@ build-rpc = "cargo build --release --features rpc"
 regen-capi-headers = { cmd = "scripts/regen-capi-headers.sh", description = "Optional: draft include/readcon-core.h via cbindgen (maintainers only, not CI)" }
 check-capi-headers = { cmd = "scripts/regen-capi-headers.sh --check", description = "Optional maintainer diff vs cbindgen; CI does not run this" }
 check-cxx-dist = { cmd = "scripts/check-cxx-dist.sh", description = "Gate: CMake/Meson/pkg-config never require cbindgen" }
+check-wrap-hash = { cmd = "scripts/check_wrap_hash.sh", description = "Gate: wrap source_hash matches published cxx SHA" }
 package-cxx = { cmd = "scripts/package-cxx.sh dist-cxx", description = "Assemble readcon-core-cxx-$VERSION.tar.gz" }
 prek = { cmd = "prek run -a", description = "Run prek hooks on all files" }
 cpc-tables = { cmd = "python paper/cpc/scripts/gen_tables.py", description = "Write CPC table fragments from committed bench JSON" }

--- a/scripts/check-cxx-dist.sh
+++ b/scripts/check-cxx-dist.sh
@@ -45,6 +45,10 @@ grep -q 'filename = "readcon-core"' Cargo.toml || die "cargo-c pkg-config filena
 [[ -x scripts/package-cxx.sh ]] || die "scripts/package-cxx.sh must be executable"
 [[ -x scripts/package-clib.sh ]] || die "scripts/package-clib.sh must be executable"
 [[ -x scripts/check-clib-dist.sh ]] || die "scripts/check-clib-dist.sh must be executable"
+[[ -x scripts/check_wrap_hash.sh ]] || die "scripts/check_wrap_hash.sh must be executable"
+if ! bash scripts/check_wrap_hash.sh; then
+    die "check_wrap_hash.sh failed"
+fi
 if ! bash scripts/check-clib-dist.sh --no-self-test; then
     die "check-clib-dist.sh --no-self-test failed"
 fi

--- a/scripts/check_wrap_hash.sh
+++ b/scripts/check_wrap_hash.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Structural gate: packaging/wrapdb/readcon-core.wrap source_hash matches
+# the published cxx tarball SHA used in the wrap file and consumer docs.
+# Does not compile. Run from the repository root.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+die() { echo "ERROR: $*" >&2; fail=1; }
+ok() { echo "OK: $*"; }
+
+WRAP="$ROOT/packaging/wrapdb/readcon-core.wrap"
+WRAP_IN="$ROOT/packaging/wrapdb/readcon-core.wrap.in"
+
+[[ -f "$WRAP" ]] || die "missing packaging/wrapdb/readcon-core.wrap"
+[[ -f "$WRAP_IN" ]] || die "missing packaging/wrapdb/readcon-core.wrap.in"
+
+cargo_ver="$(sed -n 's/^version = "\([^"]*\)"/\1/p' "$ROOT/Cargo.toml" | head -1)"
+[[ -n "$cargo_ver" ]] || die "could not read Cargo.toml version"
+
+wrap_kv() {
+  local key="$1"
+  sed -n "s/^${key}[[:space:]]*=[[:space:]]*//p" "$WRAP" | head -1
+}
+
+directory="$(wrap_kv directory)"
+source_url="$(wrap_kv source_url)"
+source_filename="$(wrap_kv source_filename)"
+source_hash_raw="$(wrap_kv source_hash)"
+source_hash="${source_hash_raw#sha256:}"
+
+if [[ "$directory" == "readcon-core-cxx-${cargo_ver}" ]]; then
+  ok "wrap directory is readcon-core-cxx-${cargo_ver}"
+else
+  die "wrap directory '${directory}' is not readcon-core-cxx-${cargo_ver}"
+fi
+
+expected_url="https://github.com/lode-org/readcon-core/releases/download/v${cargo_ver}/readcon-core-cxx-${cargo_ver}.tar.gz"
+if [[ "$source_url" == "$expected_url" ]]; then
+  ok "wrap source_url is the published v${cargo_ver} cxx tarball"
+else
+  die "wrap source_url '${source_url}' is not ${expected_url}"
+fi
+
+if [[ "$source_filename" == "readcon-core-cxx-${cargo_ver}.tar.gz" ]]; then
+  ok "wrap source_filename is readcon-core-cxx-${cargo_ver}.tar.gz"
+else
+  die "wrap source_filename '${source_filename}' is not readcon-core-cxx-${cargo_ver}.tar.gz"
+fi
+
+if [[ "$source_hash" =~ ^[0-9a-f]{64}$ ]]; then
+  ok "wrap source_hash is a 64-char sha256"
+else
+  die "wrap source_hash '${source_hash_raw}' is not a 64-char sha256"
+fi
+
+generated="$(sed -e "s/@VERSION@/${cargo_ver}/g" -e "s/@SHA256@/${source_hash}/g" "$WRAP_IN")"
+if [[ "$generated" == "$(cat "$WRAP")" ]]; then
+  ok "wrap.in substitutes to packaging/wrapdb/readcon-core.wrap"
+else
+  die "packaging/wrapdb/readcon-core.wrap does not match wrap.in + Cargo.toml + source_hash"
+fi
+
+DOC_FILES=(
+  "docs/source/getting-started.rst"
+  "docs/source/bindings.rst"
+  "docs/orgmode/getting-started.org"
+  "docs/orgmode/bindings.org"
+)
+for rel in "${DOC_FILES[@]}"; do
+  f="$ROOT/$rel"
+  [[ -f "$f" ]] || { die "missing $rel"; continue; }
+  if grep -qE "URL_HASH SHA256=${source_hash}|SHA256=${source_hash}" "$f"; then
+    ok "$rel documents SHA256=${source_hash}"
+  else
+    die "$rel does not document the wrap source_hash ${source_hash}"
+  fi
+  if grep -q "readcon-core-cxx-${cargo_ver}.tar.gz" "$f"; then
+    ok "$rel names the v${cargo_ver} cxx tarball"
+  else
+    die "$rel does not name readcon-core-cxx-${cargo_ver}.tar.gz"
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "check_wrap_hash: FAILED" >&2
+  exit 1
+fi
+echo "check_wrap_hash: all checks passed"

--- a/tests/ci_gates.rs
+++ b/tests/ci_gates.rs
@@ -1,5 +1,5 @@
-//! Structural gates for CI permission split, release action pins, and
-//! language-package version lockstep.
+//! Structural gates for CI permission split, release action pins,
+//! language-package version lockstep, and wrap source_hash lockstep.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -41,4 +41,9 @@ fn language_package_versions_match_cargo() {
 #[test]
 fn rpc_feature_has_no_ucx_dependency() {
     run_gate("scripts/check_rpc_no_ucx.sh");
+}
+
+#[test]
+fn wrap_source_hash_matches_published_cxx_tarball() {
+    run_gate("scripts/check_wrap_hash.sh");
 }


### PR DESCRIPTION
\`packaging/wrapdb/readcon-core.wrap\` must stay locked to the published cxx tarball (directory, URL, filename, SHA, wrap.in, docs).

## What

- \`scripts/check_wrap_hash.sh\`
- wired from \`check-cxx-dist.sh\` and \`tests/ci_gates.rs\`

## Test plan

- [x] \`bash scripts/check_wrap_hash.sh\`
- [ ] CI cxx / cargo test ci_gates