### PR TITLE
fix(julia): replace placeholder package UUID

### DIFF
--- a/julia/ReadCon/Project.toml
+++ b/julia/ReadCon/Project.toml
@@ -1,5 +1,5 @@
 name = "ReadCon"
-uuid = "f4d2e3b1-8c7a-4e5f-9012-3a4b5c6d7e8f"
+uuid = "db9801e4-4fe9-4ef2-a903-b9b3faaab74b"
 version = "0.14.7"
 
 [compat]

--- a/julia/ReadCon/README.md
+++ b/julia/ReadCon/README.md
@@ -53,6 +53,13 @@ If `libreadcon_core` is not on `LD_LIBRARY_PATH` / `READCON_CORE_LIB`, tests tha
 touch the FFI **fail fast** with a clear load error (they do not silently skip
 ABI checks). Pure Julia struct layout tests in `test/runtests.jl` still run.
 
+## General registry
+
+This package is not on Julia General yet. The `uuid` in `Project.toml` is
+the package identity for a future Registrator.jl submission from a
+`vX.Y.Z` tag (comment `@JuliaRegistrator register()` on that commit).
+Do not change the uuid after the first General registration.
+
 ## CI
 
 Workflow `.github/workflows/ci_julia.yml` runs when Julia is available on the


### PR DESCRIPTION
\`julia/ReadCon/Project.toml\` used a sequential uuid. Julia General has no ReadCon package. The uuid is the identity a future Registrator submission from a \`vX.Y.Z\` tag will use.

## What

- Random v4 uuid in \`Project.toml\`
- README documents the Registrator path

## Test plan

- [x] uuid is not the sequential placeholder
- [x] General/R/ReadCon/Package.toml is 404