### PR TITLE
docs(dist): pin cxx wrap hash to the published v0.14.9 tarball

### DIFF
--- a/docs/orgmode/bindings.org
+++ b/docs/orgmode/bindings.org
@@ -583,7 +583,7 @@ include(FetchContent)
 FetchContent_Declare(
   readcon-core
   URL https://github.com/lode-org/readcon-core/releases/download/v0.14.9/readcon-core-cxx-0.14.9.tar.gz
-  URL_HASH SHA256=5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e
+  URL_HASH SHA256=94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a
 )
 FetchContent_MakeAvailable(readcon-core)
 target_link_libraries(my_app PRIVATE readcon-core::shared)

--- a/docs/orgmode/getting-started.org
+++ b/docs/orgmode/getting-started.org
@@ -81,7 +81,7 @@ include(FetchContent)
 FetchContent_Declare(
   readcon-core
   URL https://github.com/lode-org/readcon-core/releases/download/v0.14.9/readcon-core-cxx-0.14.9.tar.gz
-  URL_HASH SHA256=5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e
+  URL_HASH SHA256=94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a
 )
 FetchContent_MakeAvailable(readcon-core)
 target_link_libraries(app PRIVATE readcon-core::shared)

--- a/docs/source/bindings.rst
+++ b/docs/source/bindings.rst
@@ -664,7 +664,7 @@ CMake FetchContent
     FetchContent_Declare(
       readcon-core
       URL https://github.com/lode-org/readcon-core/releases/download/v0.14.9/readcon-core-cxx-0.14.9.tar.gz
-      URL_HASH SHA256=5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e
+      URL_HASH SHA256=94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a
     )
     FetchContent_MakeAvailable(readcon-core)
     target_link_libraries(my_app PRIVATE readcon-core::shared)

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -100,7 +100,7 @@ after a prefix install. The cxx tarball on the GitHub Release is
     FetchContent_Declare(
       readcon-core
       URL https://github.com/lode-org/readcon-core/releases/download/v0.14.9/readcon-core-cxx-0.14.9.tar.gz
-      URL_HASH SHA256=5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e
+      URL_HASH SHA256=94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a
     )
     FetchContent_MakeAvailable(readcon-core)
     target_link_libraries(app PRIVATE readcon-core::shared)

--- a/packaging/wrapdb/readcon-core.wrap
+++ b/packaging/wrapdb/readcon-core.wrap
@@ -2,7 +2,7 @@
 directory = readcon-core-cxx-0.14.9
 source_url = https://github.com/lode-org/readcon-core/releases/download/v0.14.9/readcon-core-cxx-0.14.9.tar.gz
 source_filename = readcon-core-cxx-0.14.9.tar.gz
-source_hash = sha256:5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e
+source_hash = sha256:94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a
 
 [provide]
 dependency_names = readcon-core

--- a/paper/cpc/src/rg_main.org
+++ b/paper/cpc/src/rg_main.org
@@ -404,7 +404,7 @@ C ABI. The optional Pest grammar is exercised separately
 (=cargo test --features grammar=).
 The published cxx tarball on the =v0.14.9= GitHub Release is
 the CMake FetchContent URL (SHA256
-=5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e=).
+=94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a=).
 
 * Applications
 :PROPERTIES:

--- a/paper/cpc/src/rg_main.tex
+++ b/paper/cpc/src/rg_main.tex
@@ -349,7 +349,7 @@ C ABI. The optional Pest grammar is exercised separately
 (\texttt{cargo test -{}-{}features grammar}).
 The published cxx tarball on the \texttt{v0.14.9} GitHub Release is
 the CMake FetchContent URL (SHA256
-\texttt{5ae875b90faef98102949c9c0ec03d34ffab9ba5bdc8386c70e42cc153fcbd4e}).
+\texttt{94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a}).
 \section{Applications}
 \label{sec:applications}
 eOn and the amsel campaign stack consume CON as the checkpoint


### PR DESCRIPTION
## Summary

Wrap and FetchContent examples now name the v0.14.9 GitHub Release cxx SHA \`94df61bccfe2518a95b76041cf9042ef9f331d781ca400de2bfef5c070e1309a\`.

## Test plan

- [x] \`scripts/check_wrap_hash.sh\` (live .sha256 matches)